### PR TITLE
Chore: PR 생성/승인 시 Slack 알림 추가

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -20,12 +20,28 @@ jobs:
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           EVENT_NAME="${{ github.event_name }}"
 
+          # GitHub 유저네임 -> Slack User ID 매핑
+          get_slack_user_id() {
+            case "$1" in
+              "hyun907")
+                echo "U0A6NAVG516"
+                ;;
+              "ssilver")
+                echo "U0A5KB81ND9"
+                ;;
+              *)
+                echo "$1"  # 매핑이 없으면 GitHub 유저네임 그대로
+                ;;
+            esac
+          }
+
           if [ "$EVENT_NAME" == "pull_request_review" ]; then
             REVIEW_STATE="${{ github.event.review.state }}"
             # approved일 때만 알림
             if [ "$REVIEW_STATE" == "approved" ]; then
               REVIEWER="${{ github.event.review.user.login }}"
-              MESSAGE="✅ *PR 승인! 리뷰 확인하러 와주세요*\n\n*승인자:* ${REVIEWER}\n*제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${PR_AUTHOR}\n*링크:* ${PR_URL}"
+              PR_AUTHOR_SLACK_ID=$(get_slack_user_id "$PR_AUTHOR")
+              MESSAGE="✅ *PR 승인! 리뷰 확인하러 와주세요*\n\n<@${PR_AUTHOR_SLACK_ID}> *승인자:* ${REVIEWER}\n*제목:* ${PR_TITLE} (#${PR_NUMBER})\n*링크:* ${PR_URL}"
             else
               exit 0  # 코멘트나 변경요청은 알림 안 보냄
             fi
@@ -37,7 +53,8 @@ jobs:
               REQUESTED_TEAM="${{ github.event.requested_team.name }}"
               MESSAGE="👀 *리뷰 요청!*\n\n*요청 대상:* @${REQUESTED_TEAM} 팀\n*제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${PR_AUTHOR}\n*링크:* ${PR_URL}"
             else
-              MESSAGE="👀 *리뷰 요청!*\n\n*요청 대상:* @${REQUESTED_REVIEWER}\n*제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${PR_AUTHOR}\n*링크:* ${PR_URL}"
+              SLACK_USER_ID=$(get_slack_user_id "$REQUESTED_REVIEWER")
+              MESSAGE="👀 *리뷰 요청!*\n\n<@${SLACK_USER_ID}> 리뷰 부탁드려요!\n*제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${PR_AUTHOR}\n*링크:* ${PR_URL}"
             fi
           fi
 

--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -1,0 +1,49 @@
+name: PR Slack Notification
+
+on:
+  pull_request:
+    types: [review_requested]
+    branches: [main, develop]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send Slack Notification
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          EVENT_NAME="${{ github.event_name }}"
+
+          if [ "$EVENT_NAME" == "pull_request_review" ]; then
+            REVIEW_STATE="${{ github.event.review.state }}"
+            # approved일 때만 알림
+            if [ "$REVIEW_STATE" == "approved" ]; then
+              REVIEWER="${{ github.event.review.user.login }}"
+              MESSAGE="✅ *PR 승인! 리뷰 확인하러 와주세요*\n\n*승인자:* ${REVIEWER}\n*제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${PR_AUTHOR}\n*링크:* ${PR_URL}"
+            else
+              exit 0  # 코멘트나 변경요청은 알림 안 보냄
+            fi
+          else
+            # 리뷰 요청된 사람 정보 가져오기
+            REQUESTED_REVIEWER="${{ github.event.requested_reviewer.login }}"
+            if [ -z "$REQUESTED_REVIEWER" ]; then
+              # 팀이 요청된 경우
+              REQUESTED_TEAM="${{ github.event.requested_team.name }}"
+              MESSAGE="👀 *리뷰 요청!*\n\n*요청 대상:* @${REQUESTED_TEAM} 팀\n*제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${PR_AUTHOR}\n*링크:* ${PR_URL}"
+            else
+              MESSAGE="👀 *리뷰 요청!*\n\n*요청 대상:* @${REQUESTED_REVIEWER}\n*제목:* ${PR_TITLE} (#${PR_NUMBER})\n*작성자:* ${PR_AUTHOR}\n*링크:* ${PR_URL}"
+            fi
+          fi
+
+          curl -X POST \
+            -H 'Content-type: application/json' \
+            --data "{
+              \"text\": \"${MESSAGE}\"
+            }" \
+            ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [x] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

- close #8 

## ✅ 작업 목록

- [x] Slack Incoming Webhook 설정
- [x] GitHub Actions Secret에 `SLACK_WEBHOOK_URL` 등록
- [x] PR Slack 알림 워크플로우 작성
  - PR 생성 시 알림
  - PR 승인 시 알림
  - Draft PR은 알림 제외

## 🍰 논의사항

알림 타이밍
- `PR 생성/리뷰 요청` → 👀 리뷰 요청!
`PR 승인` → ✅ PR 승인!

일반 코멘트나 변경요청은 알림 안 옵니다 (알림 폭탄 방지)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Pull Request 관련 Slack 알림 자동화가 추가되었습니다.
  * PR 승인 시 승인자·PR 제목·번호·작성자·링크를 포함한 알림이 전송됩니다(승인 외 검토 제출은 알림 없음).
  * 리뷰 요청 시 특정 담당자 또는 팀에게 해당 내용이 알림으로 전달됩니다.
  * 일부 GitHub 사용자명은 대응되는 Slack 식별자로 표시되며, 매핑이 없으면 사용자명 그대로 표시됩니다.

<sub>✏️ Tip: 검토 설정에서 요약을 커스터마이즈할 수 있습니다.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->