### PR TITLE
Fix: Slack PR 알림에서 멘션 실패 - GitHub 사용자명 매핑 오류

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -26,7 +26,7 @@ jobs:
               "hyun907")
                 echo "U0A6NAVG516"
                 ;;
-              "ssilver")
+              "ssilver01")
                 echo "U0A5KB81ND9"
                 ;;
               *)


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #12 

## ✅ 작업 목록
PR 알림 워크플로우의 GitHub 사용자명 매핑 수정 (ssilver → ssilver01)

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
현재 PR 정상적으로 멘션되는 거 확인했습니다!
<img width="587" height="162" alt="image" src="https://github.com/user-attachments/assets/54948a9c-a794-4588-8cf5-8786a85ab3d8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* PR 알림 자동화 설정이 업데이트되었습니다.

---

**참고:** 이번 업데이트는 내부 인프라 변경으로, 사용자에게 직접적인 영향을 주지 않습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->