### PR TITLE
Feat: 404 페이지 작업

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,5 +1,19 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import { NotFoundPage } from '@/widgets/error/ui/NotFoundPage';
 
 export default function NotFound(): React.JSX.Element {
-  return <NotFoundPage />;
+  const router = useRouter();
+
+  const handleBack = () => {
+    // 스택이 없을 경우 홈으로 이동
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.replace('/');
+    }
+  };
+
+  return <NotFoundPage onBack={handleBack} />;
 }

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,5 @@
+import { NotFoundPage } from '@/widgets/error/ui/NotFoundPage';
+
+export default function NotFound(): React.JSX.Element {
+  return <NotFoundPage />;
+}

--- a/apps/web/src/widgets/error/ui/NotFoundPage.css.ts
+++ b/apps/web/src/widgets/error/ui/NotFoundPage.css.ts
@@ -1,0 +1,34 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/shared/ui/theme.css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100vh',
+  gap: vars.spacing.lg,
+  textAlign: 'center',
+});
+
+export const icon = style({
+  width: '4.2rem',
+  height: '4.2rem',
+  color: vars.color.bg.neutral.secondary,
+});
+
+export const title = style({
+  marginBottom: vars.spacing.sm2,
+});
+
+export const arrowWrapper = style({
+  width: '1.6rem',
+  height: '1.6rem',
+  color: vars.color.icon.tertiary,
+});
+
+export const buttonContent = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.spacing.xs,
+});

--- a/apps/web/src/widgets/error/ui/NotFoundPage.css.ts
+++ b/apps/web/src/widgets/error/ui/NotFoundPage.css.ts
@@ -32,3 +32,8 @@ export const buttonContent = style({
   alignItems: 'center',
   gap: vars.spacing.xs,
 });
+
+export const buttonWrapper = style({
+  width: '100%',
+  maxWidth: '11.6rem',
+});

--- a/apps/web/src/widgets/error/ui/NotFoundPage.tsx
+++ b/apps/web/src/widgets/error/ui/NotFoundPage.tsx
@@ -1,6 +1,5 @@
 import { Button, Text, vars } from '@/shared/ui';
-import ArrowRight from 'public/icons/ic-right-chevron.svg';
-import IcAttention from 'public/icons/ic-attention.svg';
+import { IcAttention, IcRightChevron } from 'public/icons';
 import * as styles from './NotFoundPage.css';
 
 interface NotFoundPageProps {
@@ -25,7 +24,7 @@ export function NotFoundPage({ onBack }: NotFoundPageProps): React.JSX.Element {
               이전 화면으로
             </Text>
             <div className={styles.arrowWrapper}>
-              <ArrowRight />
+              <IcRightChevron />
             </div>
           </div>
         </Button>

--- a/apps/web/src/widgets/error/ui/NotFoundPage.tsx
+++ b/apps/web/src/widgets/error/ui/NotFoundPage.tsx
@@ -1,14 +1,13 @@
-'use client';
-
 import { Button, Text, vars } from '@/shared/ui';
 import ArrowRight from 'public/icons/ic-right-chevron.svg';
-import { useRouter } from 'next/navigation';
 import IcAttention from 'public/icons/ic-attention.svg';
 import * as styles from './NotFoundPage.css';
 
-export function NotFoundPage(): React.JSX.Element {
-  const router = useRouter();
+interface NotFoundPageProps {
+  onBack: () => void;
+}
 
+export function NotFoundPage({ onBack }: NotFoundPageProps): React.JSX.Element {
   return (
     <main className={styles.container}>
       <div className={styles.icon}>
@@ -19,16 +18,18 @@ export function NotFoundPage(): React.JSX.Element {
         <br />
         찾을 수 없어요.
       </Text>
-      <Button onClick={() => router.back()} size='sm' variant='secondary'>
-        <div className={styles.buttonContent}>
-          <Text variant='b3' color={vars.color.text.secondary}>
-            이전 화면으로
-          </Text>
-          <div className={styles.arrowWrapper}>
-            <ArrowRight />
+      <div className={styles.buttonWrapper}>
+        <Button onClick={onBack} size='sm' variant='secondary'>
+          <div className={styles.buttonContent}>
+            <Text variant='b3' color={vars.color.text.secondary}>
+              이전 화면으로
+            </Text>
+            <div className={styles.arrowWrapper}>
+              <ArrowRight />
+            </div>
           </div>
-        </div>
-      </Button>
+        </Button>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/widgets/error/ui/NotFoundPage.tsx
+++ b/apps/web/src/widgets/error/ui/NotFoundPage.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Button, Text, vars } from '@/shared/ui';
+import ArrowRight from 'public/icons/ic-right-chevron.svg';
+import { useRouter } from 'next/navigation';
+import IcAttention from 'public/icons/ic-attention.svg';
+import * as styles from './NotFoundPage.css';
+
+export function NotFoundPage(): React.JSX.Element {
+  const router = useRouter();
+
+  return (
+    <main className={styles.container}>
+      <div className={styles.icon}>
+        <IcAttention />
+      </div>
+      <Text variant='t5' color={vars.color.text.secondary} className={styles.title}>
+        현재 요청한 페이지를
+        <br />
+        찾을 수 없어요.
+      </Text>
+      <Button onClick={() => router.back()} size='sm' variant='secondary'>
+        <div className={styles.buttonContent}>
+          <Text variant='b3' color={vars.color.text.secondary}>
+            이전 화면으로
+          </Text>
+          <div className={styles.arrowWrapper}>
+            <ArrowRight />
+          </div>
+        </div>
+      </Button>
+    </main>
+  );
+}


### PR DESCRIPTION
## 📝 PR 유형

* [x] 🚀 feature 기능 추가
* [ ] 🐞 버그 발생
* [ ] 🔨 리팩토링
* [ ] 📋 문서작성
* [ ] 🌍 빌드 설정 및 문제
* [ ] ETC

## 🔔 관련된 이슈 넘버

close #86

## ✅ 작업 목록

* `app/not-found.tsx`에서 404 라우팅 엔트리 구성
* 웹뷰 환경을 고려한 **안전한 뒤로가기 처리 로직** 추가

  * 히스토리 스택이 있을 경우 `router.back()`
  * 스택이 없을 경우 홈(`/`)으로 `replace`
 * `NotFoundPage` 위젯은 화면 표현만 담당하도록 하고,
웹뷰 환경에 따른 뒤로가기 정책(`history` 체크, `back / replace`)은
Next.js 라우팅 엔트리인 `app/not-found.tsx`에서 정의해
콜백 형태로 위젯에 전달하는 구조를 선택했습니다.


## 🍰 논의사항


뭔가 not-found에서 이렇게까지 해야 할까? 재사용을 너무 크게 생각한 오버엔지니어링이 아닐까?? 하다가 fsd 찾아보니 이게 정답인 거 같은데 그래도 고민이 되네요...
(이후 위젯에서 직접 라우팅 쓸 때도 있을 것 같아서 비교적 기능이 없는 이 404 PR에서 얘기 나눠보면 좋을 것 같습니다!!)


**`app/not-found.tsx`에서 콜백을 내려주는 이유 (FSD 관점)**

#### 1) UI(Widget)는 “표현만” 담당해야 함

`NotFoundPage`는 다음만 책임집니다.

* 화면 레이아웃/스타일
* 버튼 클릭 이벤트를 “호출”만 함

즉, `onBack`이라는 인터페이스만 알고, **“뒤로가기 구현 방식”은 모름**.

UI에 `useRouter()` / `window.history` / 경로(`'/'`) 같은 게 들어가면

* 라우팅 정책이 UI에 섞이고
* 재사용/테스트가 어려워지고
* 다른 환경(웹/웹뷰/네이티브 브릿지)에서 교체가 힘들어집니다.

---

#### 2) 뒤로가기 정책은 “라우팅 엔트리(app)”의 책임

`app/not-found.tsx`는 Next.js에서 라우팅 엔트리 파일이고, 여기서는 다음과 같은 로직이 자연스러울 것 같은데,

* `useRouter` 사용
* “스택이 없으면 홈으로 보낸다” 같은 정책 적용
* 환경 의존(`window.history`) 처리

즉, `app` 레이어가 **URL/네비게이션 정책을 소유**하고,
위젯은 정책을 **전달받아 실행만** 하는 구조입니다.

---

#### 3) 웹뷰 안정성 이슈를 UI에 숨기지 않기 위함

웹뷰에서는 딥링크/첫 진입/외부 링크에서 들어온 경우 `history.length`가 1일 수 있어 `back()`이 먹통이 될 수 있습니다. (물론 정상적인 로직이면 쉽게 터지진 않겠지만...)

이 대응 로직을 app 엔트리에서 명시하면:
* “웹뷰 대응 정책”이 어디에 있는지 명확
* 추후 정책 변경(예: `replace('/home')`, 네이티브 브릿지 호출)도 app에서만 수정하면 됨

---

### 코드 구조 요약

#### `app/not-found.tsx` (라우팅/정책)

* `useRouter`, `window.history` 사용
* `handleBack` 정책 정의 후 props로 전달

#### `widgets/error/ui/NotFoundPage.tsx` (UI)

* 라우팅/비즈니스 로직 없음
* `onBack` 실행만 함

---

#### 대안 A) 위젯에서 `useRouter()` 직접 사용

* 장점: 코드가 짧아 보임 (가독성)
* 단점: 위젯이 라우팅 정책을 소유 → FSD 책임 혼합, 재사용/테스트/교체 어려움, 위젯에 라우팅을 혼합해서 쓰면 어느 위젯이 라우팅 기능이 포함되어 있는지 구분이 어려워짐

#### 대안 B) app에서 콜백 내려주기 (현재 방식)

* 장점: 라우팅 정책이 엔트리에 집중, 위젯은 순수 UI 유지
* 단점: props 하나 생김 


---

## 📷 ETC
<img width="443" height="764" alt="image" src="https://github.com/user-attachments/assets/768fca85-d165-42a4-9bba-b29a7124ef20" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 404(존재하지 않는 페이지) 화면이 추가되었습니다. 안내 메시지와 이전 화면으로 돌아가기 또는 홈으로 이동하는 동작을 제공합니다.
  * 화면 내 버튼을 통해 이전 페이지로 복귀하거나 홈으로 리디렉션할 수 있습니다.

* **Style**
  * 404 페이지 전용 레이아웃 및 버튼/아이콘 스타일이 적용되어 일관된 UI를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->