### PR TITLE
Feat: 지출 내역에 따른 온보딩 연결

### DIFF
--- a/apps/mobile/shared/lib/bridge.ts
+++ b/apps/mobile/shared/lib/bridge.ts
@@ -82,6 +82,11 @@ export const appBridge = bridge({
 
         await authStorage.setTokens(accessToken, refreshToken || '');
 
+        // 지출이 있을 경우 온보딩 완료 저장
+        if (hasExpense) {
+          await onboardingStorage.completeOnboarding();
+        }
+
         return {
           success: true,
           data: {
@@ -156,7 +161,7 @@ export const appBridge = bridge({
    * 온보딩 완료
    */
   onboardingStatus: async () => {
-    await onboardingStorage.onboardingStatus();
+    return await onboardingStorage.onboardingStatus();
   },
 });
 

--- a/apps/mobile/shared/lib/bridge.ts
+++ b/apps/mobile/shared/lib/bridge.ts
@@ -4,16 +4,13 @@ import { canOpenURL, openURL } from 'expo-linking';
 import { authStorage } from './authStorage';
 import { useAppleLogin } from '@/social/useAppleLogin';
 import type { ApiResponse, SocialLoginData } from '@/shared/types/api.types';
+import { onboardingStorage } from './onboardingStorage';
 
 /**
  * Web → Native 브릿지 설정
  * Web 앱에서 호출할 수 있는 Native 메서드들을 정의
  */
 export const appBridge = bridge({
-  async getMessage(): Promise<string> {
-    return 'Hello from Native!';
-  },
-
   /**
    * 소셜 로그인
    * 네이티브에서 카카오 로그인 → 백엔드 API 호출 → 토큰 저장까지 모두 처리
@@ -146,6 +143,20 @@ export const appBridge = bridge({
     } catch (error) {
       throw new Error(error instanceof Error ? error.message : '외부 링크를 열 수 없습니다.');
     }
+  },
+
+  /**
+   * 온보딩 완료
+   */
+  completeOnboarding: async () => {
+    await onboardingStorage.completeOnboarding();
+  },
+
+  /**
+   * 온보딩 완료
+   */
+  onboardingStatus: async () => {
+    await onboardingStorage.onboardingStatus();
   },
 });
 

--- a/apps/mobile/shared/lib/onboardingStorage.ts
+++ b/apps/mobile/shared/lib/onboardingStorage.ts
@@ -1,0 +1,23 @@
+import * as SecureStore from 'expo-secure-store';
+
+const ONBOARDING_KEY = 'hasCompletedOnboarding';
+
+export const onboardingStorage = {
+  async onboardingStatus(): Promise<boolean> {
+    try {
+      const status = await SecureStore.getItemAsync(ONBOARDING_KEY);
+      return status === 'true';
+    } catch (error) {
+      console.error('온보딩 상태 확인 실패:', error);
+      return false;
+    }
+  },
+
+  async completeOnboarding(): Promise<void> {
+    try {
+      await SecureStore.setItemAsync(ONBOARDING_KEY, 'true');
+    } catch (error) {
+      console.error('온보딩 상태 저장 실패:', error);
+    }
+  },
+};

--- a/apps/web/app/(with-bottom-nav)/page.tsx
+++ b/apps/web/app/(with-bottom-nav)/page.tsx
@@ -4,11 +4,12 @@ import React from 'react';
 import { useRouter } from 'next/navigation';
 import { Home } from '@/widgets/home';
 import { WeeklyCalendar, MonthlyCalendar } from '@/widgets/calendar';
-import { WelcomeModal, OnboardingTour } from '@/features/onboarding';
+import { WelcomeModal, OnboardingTour, useOnboardingInit } from '@/features/onboarding';
 import { ROUTES } from '@/shared/constants';
 
 export default function HomePage(): React.JSX.Element {
   const router = useRouter();
+  useOnboardingInit();
 
   return (
     <>

--- a/apps/web/src/features/auth/ui/socialLogin/SocialLoginButtons.tsx
+++ b/apps/web/src/features/auth/ui/socialLogin/SocialLoginButtons.tsx
@@ -10,7 +10,6 @@ import { useBridge } from '@/shared/lib/bridge';
 import { useAuthStore } from '@/shared/stores/authStore';
 import { getPlatform } from '@/shared/utils';
 import { ROUTES } from '@/shared/constants';
-import { useOnboardingStore } from '@/features/onboarding';
 
 /**
  * 소셜 로그인 버튼 컴포넌트
@@ -19,7 +18,6 @@ import { useOnboardingStore } from '@/features/onboarding';
  */
 export const SocialLoginButtons = () => {
   const [isNativeLoginLoading, setIsNativeLoginLoading] = useState(false);
-  const { hydrateFromServer } = useOnboardingStore();
   const platform = getPlatform();
   const router = useRouter();
   const toast = useToast();
@@ -57,10 +55,6 @@ export const SocialLoginButtons = () => {
       await syncNativeToken();
       setIsNativeLoginLoading(false);
       toast.success('로그인에 성공했어요');
-      // 지출이 있으면 온보딩 X
-      if (data?.hasExpense) {
-        hydrateFromServer(true);
-      }
       if (data?.termsAgreed) {
         router.replace(ROUTES.HOME);
       } else {

--- a/apps/web/src/features/auth/ui/socialLogin/SocialLoginButtons.tsx
+++ b/apps/web/src/features/auth/ui/socialLogin/SocialLoginButtons.tsx
@@ -10,6 +10,7 @@ import { useBridge } from '@/shared/lib/bridge';
 import { useAuthStore } from '@/shared/stores/authStore';
 import { getPlatform } from '@/shared/utils';
 import { ROUTES } from '@/shared/constants';
+import { useOnboardingStore } from '@/features/onboarding';
 
 /**
  * 소셜 로그인 버튼 컴포넌트
@@ -18,6 +19,7 @@ import { ROUTES } from '@/shared/constants';
  */
 export const SocialLoginButtons = () => {
   const [isNativeLoginLoading, setIsNativeLoginLoading] = useState(false);
+  const { hydrateFromServer } = useOnboardingStore();
   const platform = getPlatform();
   const router = useRouter();
   const toast = useToast();
@@ -55,6 +57,10 @@ export const SocialLoginButtons = () => {
       await syncNativeToken();
       setIsNativeLoginLoading(false);
       toast.success('로그인에 성공했어요');
+      // 지출이 있으면 온보딩 X
+      if (data?.hasExpense) {
+        hydrateFromServer(true);
+      }
       if (data?.termsAgreed) {
         router.replace(ROUTES.HOME);
       } else {

--- a/apps/web/src/features/onboarding/index.ts
+++ b/apps/web/src/features/onboarding/index.ts
@@ -1,3 +1,4 @@
 export { WelcomeModal } from './ui/WelcomeModal/WelcomeModal';
 export { OnboardingTour } from './ui/OnboardingTour/OnboardingTour';
 export { useOnboardingStore } from './model/onboardingStore';
+export { useOnboardingInit } from './lib/useOnboardingInit';

--- a/apps/web/src/features/onboarding/lib/useOnboardingInit.ts
+++ b/apps/web/src/features/onboarding/lib/useOnboardingInit.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useBridge } from '@/shared/lib/bridge';
+import { useOnboardingStore } from '../model/onboardingStore';
+
+/**
+ * 앱 로드 시 bridge.onboardingStatus()를 호출하여
+ * Zustand 온보딩 스토어를 hydrate하는 훅
+ *
+ * HomePage에서 한 번만 호출
+ */
+export function useOnboardingInit() {
+  const bridge = useBridge();
+  const hydrateFromServer = useOnboardingStore((s) => s.hydrateFromServer);
+  const hasChecked = useRef(false);
+
+  useEffect(() => {
+    if (hasChecked.current) return;
+    if (!bridge) return;
+
+    hasChecked.current = true;
+
+    bridge
+      .onboardingStatus()
+      .then((completed) => {
+        hydrateFromServer(completed);
+      })
+      .catch(() => {
+        // bridge 호출 실패 시 localStorage 상태 유지
+      });
+  }, [bridge, hydrateFromServer]);
+}

--- a/apps/web/src/features/onboarding/lib/useOnboardingTour.ts
+++ b/apps/web/src/features/onboarding/lib/useOnboardingTour.ts
@@ -1,6 +1,7 @@
 import { useOnboardingStore } from '../model/onboardingStore';
 import { STEPS } from '../config/steps';
 import { useOnboardingElement } from './useOnboardingElement';
+import { useBridge } from '@/shared/lib/bridge';
 
 /**
  * OnboardingTour의 비즈니스 로직을 담당하는 훅
@@ -9,6 +10,7 @@ import { useOnboardingElement } from './useOnboardingElement';
  */
 export function useOnboardingTour() {
   const { flow, step, nextStep, endTour } = useOnboardingStore();
+  const bridge = useBridge();
   const currentStep = STEPS[step];
 
   const rect = useOnboardingElement(flow === 'tour', currentStep?.key);
@@ -19,6 +21,7 @@ export function useOnboardingTour() {
   const handleNext = () => {
     if (step === STEPS.length - 1) {
       endTour();
+      bridge?.completeOnboarding();
     } else {
       nextStep();
     }

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -44,4 +44,10 @@ export type AppBridge = {
 
   // 외부 링크 열기 (인앱 브라우저)
   openExternalUrl: (url: string) => Promise<void>;
+
+  // 온보딩 완료
+  completeOnboarding: () => Promise<void>;
+
+  // 온보딩 상태 확인
+  onboardingStatus: () => Promise<boolean>;
 };


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

- close #122 

## ✅ 작업 목록

네이티브 Bridge(onboardingStatus)를 활용한 온보딩 상태 확인 로직 구현했습니다.
온보딩 완료 시 네이티브 SecureStore에 동기화 로직 설계

### 온보딩 상태 관리 아키텍처
Zustand 스토어(useOnboardingStore)는 훅을 사용할 수 없기 때문에, React 훅 레이어에서 Bridge와 Store를 연결하는 패턴으로 구현했습니다.

- Zustand 스토어는 변경 없이 유지 — flow 관리(welcome → tour → none)는 기존 그대로 
useOnboardingInit 훅으로 Bridge ↔ Store 연결 — 컴포넌트 레이어에서 useBridge + useOnboardingStore를 조합


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 온보딩 완료 상태 추적 기능이 추가되었습니다.
  * 로그인 완료 시 온보딩 진행 상태가 자동으로 저장됩니다.
  * 앱 재시작 후에도 온보딩 진행 상태가 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->