### PR TITLE
Refactor: 카카오 로그인 백엔드가 기대하는 응답 형식으로 변경 및 리이슈 연동

### DIFF
--- a/apps/mobile/apis/instance.ts
+++ b/apps/mobile/apis/instance.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+// bridge.ts의 카카오/리이슈와 동일한 기준. env 없으면 같은 기본 URL 사용 (애플 로그인 등 baseAPI 쓰는 요청용)
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'https://api.nitrogen18.store';
 
 export const baseAPI = axios.create({
   baseURL: API_BASE_URL,

--- a/apps/mobile/apis/instance.ts
+++ b/apps/mobile/apis/instance.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
-// bridge.ts의 카카오/리이슈와 동일한 기준. env 없으면 같은 기본 URL 사용 (애플 로그인 등 baseAPI 쓰는 요청용)
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'https://api.nitrogen18.store';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+if (!API_BASE_URL) {
+  throw new Error('EXPO_PUBLIC_API_URL is not set');
+}
 
 export const baseAPI = axios.create({
   baseURL: API_BASE_URL,

--- a/apps/mobile/apis/postAppleLogin.ts
+++ b/apps/mobile/apis/postAppleLogin.ts
@@ -10,7 +10,8 @@ export const postAppleLogin = async ({
   try {
     const response = await baseAPI.post(`/api/auth/apple/login?code=${code}`);
 
-    const { result } = response.data;
+    // 백엔드가 result 래핑 여부에 상관없이 동작하도록 (bridge 카카오와 동일한 방식)
+    const result = response.data?.result ?? response.data;
 
     return {
       success: true,

--- a/apps/mobile/apis/postKakaoLogin.ts
+++ b/apps/mobile/apis/postKakaoLogin.ts
@@ -1,0 +1,34 @@
+import { isAxiosError } from 'axios';
+import { baseAPI } from './instance';
+import type { ApiResponse, SocialLoginData } from '@/shared/types/api.types';
+
+export const postKakaoLogin = async ({
+  accessToken,
+}: {
+  accessToken: string;
+}): Promise<ApiResponse<SocialLoginData>> => {
+  try {
+    const response = await baseAPI.post('/api/auth/kakao/login', { accessToken });
+
+    const result = response.data?.result ?? response.data;
+    const newAccessToken = result.accessToken ?? result.access_token;
+    const newRefreshToken = result.refreshToken ?? result.refresh_token ?? '';
+
+    return {
+      success: true,
+      data: {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+      },
+    };
+  } catch (error) {
+    if (isAxiosError(error) && error.response) {
+      throw new Error(
+        typeof error.response.data === 'string'
+          ? error.response.data
+          : '서버 로그인에 실패했습니다.'
+      );
+    }
+    throw new Error('서버 통신 중 오류가 발생했습니다.');
+  }
+};

--- a/apps/mobile/apis/postReissue.ts
+++ b/apps/mobile/apis/postReissue.ts
@@ -1,0 +1,26 @@
+import { isAxiosError } from 'axios';
+import { baseAPI } from './instance';
+
+export const postReissue = async (
+  refreshToken: string
+): Promise<{ accessToken: string; refreshToken: string } | null> => {
+  try {
+    const response = await baseAPI.post(
+      '/api/auth/reissue',
+      {},
+      { headers: { RefreshToken: refreshToken } }
+    );
+
+    const data = response.data?.result ?? response.data;
+    const newAccessToken = data?.accessToken ?? data?.access_token;
+    const newRefreshToken = data?.refreshToken ?? data?.refresh_token ?? refreshToken;
+
+    if (!newAccessToken) return null;
+    return { accessToken: newAccessToken, refreshToken: newRefreshToken };
+  } catch (error) {
+    if (isAxiosError(error)) {
+      console.warn('[postReissue]', error.response?.status, error.response?.data);
+    }
+    return null;
+  }
+};

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -31,7 +31,7 @@ if (KAKAO_NATIVE_APP_KEY) {
 
 export default function HomeScreen() {
   const webViewRef = useRef<WebViewType>(null);
-  const [initialUrl, setInitialUrl] = useState<string>(WEBVIEW_URL || '');
+  const [initialUrl] = useState<string>(WEBVIEW_URL || '');
 
   // WebView 로드 완료 시 스플래시 화면 숨기기
   const handleWebViewLoad = useCallback(() => {
@@ -55,9 +55,6 @@ export default function HomeScreen() {
           style={styles.webview}
           webviewDebuggingEnabled
           domStorageEnabled={true}
-          // 쿠키 설정
-          sharedCookiesEnabled={true}
-          thirdPartyCookiesEnabled={true}
           // 모든 URL 허용
           originWhitelist={['*']}
           // JavaScript 활성화

--- a/apps/mobile/shared/lib/bridge.ts
+++ b/apps/mobile/shared/lib/bridge.ts
@@ -40,23 +40,19 @@ export const appBridge = bridge({
 
         const backendData = await backendResponse.json();
 
-        // 3. 백엔드 응답에서 토큰 추출 (result.accessToken)
-        const accessToken = backendData.result?.accessToken;
-        const refreshToken = backendData.result?.refreshToken || null;
+        const result = backendData.result ?? backendData;
+        const accessToken = result.accessToken ?? result.access_token;
+        const refreshToken = result.refreshToken ?? result.refresh_token ?? '';
 
         if (!accessToken) {
           throw new Error('백엔드 응답에 accessToken이 없습니다.');
         }
 
-        // 4. 백엔드 토큰을 SecureStore에 저장
-        await authStorage.setTokens(accessToken, refreshToken || '');
+        await authStorage.setTokens(accessToken, refreshToken);
 
         return {
           success: true,
-          data: {
-            accessToken,
-            refreshToken: refreshToken || '',
-          },
+          data: { accessToken, refreshToken },
         };
       } else if (type === 'apple') {
         const result = await useAppleLogin();
@@ -70,7 +66,7 @@ export const appBridge = bridge({
           throw new Error('애플 로그인 응답에 accessToken이 없습니다.');
         }
 
-        await authStorage.setTokens(accessToken, refreshToken || '');
+        await authStorage.setTokens(accessToken, refreshToken);
 
         return {
           success: true,
@@ -97,14 +93,51 @@ export const appBridge = bridge({
   },
 
   /**
-   * 저장된 액세스 토큰 조회
+   * 저장된 accessToken만 조회. reissue는 네이티브 reissueAccessToken()만 사용 (웹에 refreshToken 노출 안 함)
    */
-  async getAccessToken(): Promise<{ accessToken: string | null }> {
+  async getAccessToken(): Promise<string | null> {
     try {
-      const accessToken = await authStorage.getAccessToken();
-      return { accessToken };
+      return await authStorage.getAccessToken();
     } catch (error) {
-      return { accessToken: null };
+      console.error(error);
+      return null;
+    }
+  },
+
+  /**
+   * 네이티브에서 리프레시 토큰으로 액세스 토큰 재발급
+   * 웹이 401 받으면 이 메서드 호출 → 네이티브가 reissue API 호출 후 새 accessToken 반환
+   */
+  async reissueAccessToken(): Promise<{ accessToken: string } | null> {
+    console.log('[NATIVE] reissueAccessToken called');
+    try {
+      const refreshToken = await authStorage.getRefreshToken();
+      console.log('[NATIVE] has refreshToken?', !!refreshToken);
+      if (!refreshToken) return null;
+
+      const res = await fetch('https://api.nitrogen18.store/api/auth/reissue', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          RefreshToken: refreshToken,
+        },
+        body: JSON.stringify({}),
+      });
+      console.log('[NATIVE] reissue status', res.status);
+
+      if (!res.ok) return null;
+
+      const data = await res.json();
+      const newAccessToken = data?.result?.accessToken ?? data?.accessToken;
+      const newRefreshToken = data?.result?.refreshToken ?? data?.refreshToken ?? refreshToken;
+      console.log('[NATIVE] reissue success, new access?', !!newAccessToken);
+      if (!newAccessToken) return null;
+
+      await authStorage.setTokens(newAccessToken, newRefreshToken);
+      return { accessToken: newAccessToken };
+    } catch (error) {
+      console.error('[Bridge] reissueAccessToken failed:', error);
+      return null;
     }
   },
 
@@ -116,7 +149,7 @@ export const appBridge = bridge({
       await logout();
       await authStorage.clearTokens();
     } catch (error) {
-      throw new Error('로그아웃에 실패했습니다.');
+      throw new Error(error instanceof Error ? error.message : '로그아웃에 실패했습니다.');
     }
   },
 

--- a/apps/mobile/shared/lib/bridge.ts
+++ b/apps/mobile/shared/lib/bridge.ts
@@ -1,5 +1,5 @@
 import { bridge, createWebView } from '@webview-bridge/react-native';
-import { login, logout, me } from '@react-native-kakao/user';
+import { login, logout } from '@react-native-kakao/user';
 import { canOpenURL, openURL } from 'expo-linking';
 import { authStorage } from './authStorage';
 import { useAppleLogin } from '@/social/useAppleLogin';
@@ -143,14 +143,16 @@ export const appBridge = bridge({
 
   /**
    * 로그아웃
+   * - 카카오 로그인 시에만 Kakao SDK logout 호출 (애플 로그인 시에는 세션 없음 → 실패해도 무시)
+   * - 항상 우리 앱 토큰(access/refresh)은 삭제
    */
   async requestLogout(): Promise<void> {
     try {
       await logout();
-      await authStorage.clearTokens();
-    } catch (error) {
-      throw new Error(error instanceof Error ? error.message : '로그아웃에 실패했습니다.');
+    } catch {
+      // 애플 로그인 사용자는 카카오 세션이 없어 실패할 수 있음 → 무시하고 토큰만 삭제
     }
+    await authStorage.clearTokens();
   },
 
   /**

--- a/apps/mobile/shared/lib/bridge.ts
+++ b/apps/mobile/shared/lib/bridge.ts
@@ -24,26 +24,13 @@ export const appBridge = bridge({
         // 1. 카카오 SDK 로그인
         const kakaoResult = await login();
 
-        // 2. 카카오 사용자 정보 가져오기
-        const kakaoUser = await me();
-
-        // 3. 백엔드가 기대하는 형식으로 데이터 변환
-        const kakaoUserInfo = {
-          id: kakaoUser.id,
-          properties: {
-            nickname: kakaoUser.nickname || kakaoUser.name || '사용자',
-          },
-          // TODO: 백엔드 API 스펙 확인 후 필요하면 주석 해제
-          // kakao_account: {
-          //   email: kakaoUser.email,
-          // },
-        };
-
-        // 4. 백엔드로 사용자 정보 전송하여 서비스 토큰 받기
+        // 2. 백엔드로 사용자 정보 전송하여 서비스 토큰 받기
         const backendResponse = await fetch('https://api.nitrogen18.store/api/auth/kakao/login', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(kakaoUserInfo),
+          body: JSON.stringify({
+            accessToken: kakaoResult.accessToken,
+          }),
         });
 
         if (!backendResponse.ok) {
@@ -53,7 +40,7 @@ export const appBridge = bridge({
 
         const backendData = await backendResponse.json();
 
-        // 5. 백엔드 응답에서 토큰 추출 (result.accessToken)
+        // 3. 백엔드 응답에서 토큰 추출 (result.accessToken)
         const accessToken = backendData.result?.accessToken;
         const refreshToken = backendData.result?.refreshToken || null;
 
@@ -61,7 +48,7 @@ export const appBridge = bridge({
           throw new Error('백엔드 응답에 accessToken이 없습니다.');
         }
 
-        // 6. 백엔드 토큰을 SecureStore에 저장
+        // 4. 백엔드 토큰을 SecureStore에 저장
         await authStorage.setTokens(accessToken, refreshToken || '');
 
         return {

--- a/apps/mobile/shared/lib/bridge.ts
+++ b/apps/mobile/shared/lib/bridge.ts
@@ -66,7 +66,7 @@ export const appBridge = bridge({
           throw new Error('애플 로그인 응답에 accessToken이 없습니다.');
         }
 
-        await authStorage.setTokens(accessToken, refreshToken);
+        await authStorage.setTokens(accessToken, refreshToken || '');
 
         return {
           success: true,

--- a/apps/mobile/shared/lib/bridge.ts
+++ b/apps/mobile/shared/lib/bridge.ts
@@ -1,6 +1,8 @@
 import { bridge, createWebView } from '@webview-bridge/react-native';
 import { login, logout } from '@react-native-kakao/user';
 import { canOpenURL, openURL } from 'expo-linking';
+import { postKakaoLogin } from '@/apis/postKakaoLogin';
+import { postReissue } from '@/apis/postReissue';
 import { authStorage } from './authStorage';
 import { useAppleLogin } from '@/social/useAppleLogin';
 import type { ApiResponse, SocialLoginData } from '@/shared/types/api.types';
@@ -18,38 +20,19 @@ export const appBridge = bridge({
   async socialLogin(type: 'kakao' | 'apple'): Promise<ApiResponse<SocialLoginData>> {
     try {
       if (type === 'kakao') {
-        // 1. 카카오 SDK 로그인
         const kakaoResult = await login();
+        const result = await postKakaoLogin({ accessToken: kakaoResult.accessToken });
 
-        // 2. 백엔드로 사용자 정보 전송하여 서비스 토큰 받기
-        const backendResponse = await fetch('https://api.nitrogen18.store/api/auth/kakao/login', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            accessToken: kakaoResult.accessToken,
-          }),
-        });
-
-        if (!backendResponse.ok) {
-          const errorText = await backendResponse.text();
-          throw new Error(`백엔드 API 오류: ${backendResponse.status} - ${errorText}`);
-        }
-
-        const backendData = await backendResponse.json();
-
-        const result = backendData.result ?? backendData;
-        const accessToken = result.accessToken ?? result.access_token;
-        const refreshToken = result.refreshToken ?? result.refresh_token ?? '';
-
-        if (!accessToken) {
+        if (!result.data?.accessToken) {
           throw new Error('백엔드 응답에 accessToken이 없습니다.');
         }
 
-        await authStorage.setTokens(accessToken, refreshToken);
+        const { accessToken, refreshToken } = result.data;
+        await authStorage.setTokens(accessToken, refreshToken ?? '');
 
         return {
           success: true,
-          data: { accessToken, refreshToken },
+          data: { accessToken, refreshToken: refreshToken ?? '' },
         };
       } else if (type === 'apple') {
         const result = await useAppleLogin();
@@ -111,32 +94,15 @@ export const appBridge = bridge({
    * 웹이 401 받으면 이 메서드 호출 → 네이티브가 reissue API 호출 후 새 accessToken 반환
    */
   async reissueAccessToken(): Promise<{ accessToken: string } | null> {
-    console.log('[NATIVE] reissueAccessToken called');
     try {
       const refreshToken = await authStorage.getRefreshToken();
-      console.log('[NATIVE] has refreshToken?', !!refreshToken);
       if (!refreshToken) return null;
 
-      const res = await fetch('https://api.nitrogen18.store/api/auth/reissue', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          RefreshToken: refreshToken,
-        },
-        body: JSON.stringify({}),
-      });
-      console.log('[NATIVE] reissue status', res.status);
+      const tokens = await postReissue(refreshToken);
+      if (!tokens) return null;
 
-      if (!res.ok) return null;
-
-      const data = await res.json();
-      const newAccessToken = data?.result?.accessToken ?? data?.accessToken;
-      const newRefreshToken = data?.result?.refreshToken ?? data?.refreshToken ?? refreshToken;
-      console.log('[NATIVE] reissue success, new access?', !!newAccessToken);
-      if (!newAccessToken) return null;
-
-      await authStorage.setTokens(newAccessToken, newRefreshToken);
-      return { accessToken: newAccessToken };
+      await authStorage.setTokens(tokens.accessToken, tokens.refreshToken);
+      return { accessToken: tokens.accessToken };
     } catch (error) {
       console.error('[Bridge] reissueAccessToken failed:', error);
       return null;

--- a/apps/web/app/(with-bottom-nav)/page.tsx
+++ b/apps/web/app/(with-bottom-nav)/page.tsx
@@ -6,9 +6,19 @@ import { Home } from '@/widgets/home';
 import { WeeklyCalendar, MonthlyCalendar } from '@/widgets/calendar';
 import { WelcomeModal, OnboardingTour } from '@/features/onboarding';
 import { ROUTES } from '@/shared/constants';
+import { useAuthStore } from '@/shared/stores/authStore';
 
 export default function HomePage(): React.JSX.Element {
   const router = useRouter();
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+
+  const handleExpireAccessTokenAndReload = () => {
+    // 리이슈 테스트: 액세스만 비우면 401 → 네이티브 reissue 시도
+    setAccessToken('');
+    window.location.reload();
+  };
+
+  const isDev = process.env.NODE_ENV === 'development';
 
   return (
     <>
@@ -28,6 +38,29 @@ export default function HomePage(): React.JSX.Element {
       {/* 온보딩 전용 컴포넌트 */}
       <WelcomeModal />
       <OnboardingTour />
+
+      {/* 개발 전용: 액세스토큰 만료 시뮬레이션 + 새로고침 (리이슈 테스트) */}
+      {isDev && (
+        <button
+          type='button'
+          onClick={handleExpireAccessTokenAndReload}
+          style={{
+            position: 'fixed',
+            bottom: 100,
+            right: 16,
+            zIndex: 9999,
+            padding: '8px 12px',
+            fontSize: 12,
+            backgroundColor: '#ff6b6b',
+            color: '#fff',
+            border: 'none',
+            borderRadius: 8,
+            cursor: 'pointer',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
+          }}>
+          [DEV] 토큰 만료 + 새로고침
+        </button>
+      )}
     </>
   );
 }

--- a/apps/web/app/(with-bottom-nav)/page.tsx
+++ b/apps/web/app/(with-bottom-nav)/page.tsx
@@ -6,19 +6,9 @@ import { Home } from '@/widgets/home';
 import { WeeklyCalendar, MonthlyCalendar } from '@/widgets/calendar';
 import { WelcomeModal, OnboardingTour } from '@/features/onboarding';
 import { ROUTES } from '@/shared/constants';
-import { useAuthStore } from '@/shared/stores/authStore';
 
 export default function HomePage(): React.JSX.Element {
   const router = useRouter();
-  const setAccessToken = useAuthStore((state) => state.setAccessToken);
-
-  const handleExpireAccessTokenAndReload = () => {
-    // 리이슈 테스트: 액세스만 비우면 401 → 네이티브 reissue 시도
-    setAccessToken('');
-    window.location.reload();
-  };
-
-  const isDev = process.env.NODE_ENV === 'development';
 
   return (
     <>
@@ -38,29 +28,6 @@ export default function HomePage(): React.JSX.Element {
       {/* 온보딩 전용 컴포넌트 */}
       <WelcomeModal />
       <OnboardingTour />
-
-      {/* 개발 전용: 액세스토큰 만료 시뮬레이션 + 새로고침 (리이슈 테스트) */}
-      {isDev && (
-        <button
-          type='button'
-          onClick={handleExpireAccessTokenAndReload}
-          style={{
-            position: 'fixed',
-            bottom: 100,
-            right: 16,
-            zIndex: 9999,
-            padding: '8px 12px',
-            fontSize: 12,
-            backgroundColor: '#ff6b6b',
-            color: '#fff',
-            border: 'none',
-            borderRadius: 8,
-            cursor: 'pointer',
-            boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
-          }}>
-          [DEV] 토큰 만료 + 새로고침
-        </button>
-      )}
     </>
   );
 }

--- a/apps/web/src/features/auth/api/deleteWithdraw.ts
+++ b/apps/web/src/features/auth/api/deleteWithdraw.ts
@@ -1,5 +1,23 @@
-import { authApi, ENDPOINT } from '@/shared/api';
+import { authenticatedApiClient, ENDPOINT, type ApiResponse } from '@/shared/api';
 
-export const deleteWithdraw = async () => {
-  return await authApi.delete<string>(ENDPOINT.AUTH.WITHDRAW);
+/** 회원 탈퇴 (204 No Content 또는 JSON 응답 모두 처리) */
+export const deleteWithdraw = async (): Promise<ApiResponse<string>> => {
+  const response = await authenticatedApiClient.delete(ENDPOINT.AUTH.WITHDRAW);
+
+  if (!response.ok) {
+    const body = await response.text();
+    let message = response.statusText;
+    try {
+      const parsed = body ? JSON.parse(body) : {};
+      if (parsed?.message) message = parsed.message;
+    } catch {
+      if (body) message = body;
+    }
+    throw new Error(message);
+  }
+
+  if (response.status === 204 || !response.body) {
+    return { isSuccess: true, code: '200', message: '', result: '' };
+  }
+  return response.json<ApiResponse<string>>();
 };

--- a/apps/web/src/features/auth/api/postLogout.ts
+++ b/apps/web/src/features/auth/api/postLogout.ts
@@ -1,5 +1,0 @@
-import { authApi, ENDPOINT } from '@/shared/api';
-
-export const postLogout = async () => {
-  return await authApi.post<string>(ENDPOINT.AUTH.LOGOUT);
-};

--- a/apps/web/src/features/auth/model/authQueries.ts
+++ b/apps/web/src/features/auth/model/authQueries.ts
@@ -1,14 +1,8 @@
 import { mutationOptions } from '@tanstack/react-query';
-import { postLogout } from '../api/postLogout';
 import { deleteWithdraw } from '../api/deleteWithdraw';
 import { patchTerms } from '../api/patchTerms';
 
 export const authQueries = {
-  logoutMutation: () =>
-    mutationOptions({
-      mutationFn: () => postLogout(),
-    }),
-
   withdrawMutation: () =>
     mutationOptions({
       mutationFn: () => deleteWithdraw(),

--- a/apps/web/src/features/auth/model/useLogout.ts
+++ b/apps/web/src/features/auth/model/useLogout.ts
@@ -1,41 +1,43 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
 import { useAuthStore } from '@/shared/stores/authStore';
 import { useToast } from '@/shared/ui';
 import { useBridge } from '@/shared/lib/bridge';
-import { authQueries } from './authQueries';
 import { getPlatform } from '@/shared/utils';
 
+/** 백엔드 API 없이 클라이언트만 정리 (토큰/스토리지 비우고 로그인 화면으로) */
 export const useLogout = () => {
   const router = useRouter();
   const toast = useToast();
   const clearAuth = useAuthStore((state) => state.clearAuth);
   const bridge = useBridge();
   const platform = getPlatform();
+  const [isPending, setIsPending] = useState(false);
 
-  const { mutate: logout, isPending } = useMutation({
-    ...authQueries.logoutMutation(),
-    onSuccess: async () => {
-      // 웹뷰 환경에서는 네이티브 로그아웃도 호출
+  const handleLogout = useCallback(async () => {
+    setIsPending(true);
+    try {
       if ((platform === 'ios' || platform === 'android') && bridge) {
         try {
-          // 카카오 로그아웃 + 모든 토큰 삭제
           await bridge.requestLogout();
         } catch {
-          // 네이티브 로그아웃 실패
+          // 네이티브 로그아웃 실패해도 로컬 정리 진행
         }
       }
-
       clearAuth();
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('auth-storage');
+      }
       toast.success('로그아웃이 완료되었어요');
       router.replace('/login');
-    },
-    onError: () => {
+    } catch {
       toast.attention('로그아웃에 실패했어요. 다시 시도해주세요.');
-    },
-  });
+    } finally {
+      setIsPending(false);
+    }
+  }, [bridge, platform, clearAuth, toast, router]);
 
-  return { handleLogout: logout, isPending };
+  return { handleLogout, isPending };
 };

--- a/apps/web/src/features/auth/model/useLogout.ts
+++ b/apps/web/src/features/auth/model/useLogout.ts
@@ -2,16 +2,14 @@
 
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
-import { useAuthStore } from '@/shared/stores/authStore';
 import { useToast } from '@/shared/ui';
 import { useBridge } from '@/shared/lib/bridge';
-import { getPlatform } from '@/shared/utils';
+import { clearAllUserStorage, getPlatform } from '@/shared/utils';
 
 /** 백엔드 API 없이 클라이언트만 정리 (토큰/스토리지 비우고 로그인 화면으로) */
 export const useLogout = () => {
   const router = useRouter();
   const toast = useToast();
-  const clearAuth = useAuthStore((state) => state.clearAuth);
   const bridge = useBridge();
   const platform = getPlatform();
   const [isPending, setIsPending] = useState(false);
@@ -26,10 +24,7 @@ export const useLogout = () => {
           // 네이티브 로그아웃 실패해도 로컬 정리 진행
         }
       }
-      clearAuth();
-      if (typeof window !== 'undefined') {
-        localStorage.removeItem('auth-storage');
-      }
+      clearAllUserStorage();
       toast.success('로그아웃이 완료되었어요');
       router.replace('/login');
     } catch {
@@ -37,7 +32,7 @@ export const useLogout = () => {
     } finally {
       setIsPending(false);
     }
-  }, [bridge, platform, clearAuth, toast, router]);
+  }, [bridge, platform, toast, router]);
 
   return { handleLogout, isPending };
 };

--- a/apps/web/src/features/auth/model/useWithdraw.ts
+++ b/apps/web/src/features/auth/model/useWithdraw.ts
@@ -2,24 +2,27 @@
 
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
-import { useAuthStore } from '@/shared/stores/authStore';
 import { useToast } from '@/shared/ui';
+import { clearAllUserStorage } from '@/shared/utils';
 import { authQueries } from './authQueries';
 
 export const useWithdraw = () => {
   const router = useRouter();
   const toast = useToast();
-  const clearAuth = useAuthStore((state) => state.clearAuth);
 
   const { mutate: withdraw, isPending } = useMutation({
     ...authQueries.withdrawMutation(),
     onSuccess: () => {
-      clearAuth();
+      clearAllUserStorage();
       toast.success('회원탈퇴가 완료되었어요');
       router.replace('/login');
     },
-    onError: () => {
-      toast.attention('회원 탈퇴에 실패했어요. 다시 시도해주세요.');
+    onError: (error: Error) => {
+      const message =
+        error?.message && error.message !== 'Failed to fetch'
+          ? error.message
+          : '회원 탈퇴에 실패했어요. 다시 시도해주세요.';
+      toast.attention(message);
     },
   });
 

--- a/apps/web/src/features/auth/ui/socialLogin/SocialLoginButtons.tsx
+++ b/apps/web/src/features/auth/ui/socialLogin/SocialLoginButtons.tsx
@@ -22,14 +22,14 @@ export const SocialLoginButtons = () => {
   const router = useRouter();
   const toast = useToast();
   const bridge = useBridge();
-  const setAuth = useAuthStore((state) => state.setAuth);
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
 
   const syncNativeToken = async () => {
     if ((platform === 'ios' || platform === 'android') && bridge) {
       try {
-        const { accessToken } = await bridge.getAccessToken();
+        const accessToken = await bridge.getAccessToken();
         if (accessToken) {
-          setAuth({ accessToken });
+          setAccessToken(accessToken);
         }
       } catch {
         // 토큰 로드 실패

--- a/apps/web/src/providers/Providers.tsx
+++ b/apps/web/src/providers/Providers.tsx
@@ -6,14 +6,17 @@ import { getQueryClient } from './query-client';
 import { ToastContainer } from '@/shared/ui/toast';
 import { AuthGuard } from '@/shared/lib/auth/AuthGuard';
 import { initializeBridge } from '@/shared/lib/bridge';
+import { useAuthStore } from '@/shared/stores/authStore';
 import { type ReactNode, useEffect } from 'react';
 
 export function Providers({ children }: { children: ReactNode }): ReactNode {
   const queryClient = getQueryClient();
 
-  // 브릿지 초기화
   useEffect(() => {
-    initializeBridge();
+    // 브릿지 초기화 (재시도 내부 처리)
+    void initializeBridge();
+    // authStore: localStorage에서 복원 (skipHydration 사용 시 필요)
+    useAuthStore.persist.rehydrate();
   }, []);
 
   return (

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -1,33 +1,36 @@
 import ky from 'ky';
 import { useAuthStore } from '@/shared/stores/authStore';
-import { API_BASE_URL, API_TIMEOUT, API_RETRY_LIMIT, API_RETRY_BACKOFF_LIMIT } from './constants';
-import { ENDPOINT } from './endpoint';
-import type { ApiResponse } from './types';
-import type { components } from './schema';
-
-type TokenReissueResult = components['schemas']['TokenReissueResultDTO'];
+import { API_BASE_URL, API_TIMEOUT } from './constants';
 
 /**
  * 동시 다발적 401 응답 시 reissue를 한 번만 호출하기 위한 Promise 잠금
  */
 let refreshPromise: Promise<string | null> | null = null;
 
+/**
+ * [401 처리] 웹에서는 /api/auth/reissue를 직접 호출하지 않음.
+ * - bridge.reissueAccessToken() 호출 → 네이티브가 reissue 수행 후 accessToken 반환
+ * - 웹은 반환된 accessToken으로 스토어 갱신 후 재시도만 함
+ */
 const refreshAccessToken = async (): Promise<string | null> => {
   if (refreshPromise) return refreshPromise;
 
   refreshPromise = (async () => {
     try {
-      const tokenResponse = await apiClient
-        .post(ENDPOINT.AUTH.REISSUE, { credentials: 'include' })
-        .json<ApiResponse<TokenReissueResult>>();
+      if (typeof window === 'undefined') return null;
 
-      if (tokenResponse.result?.accessToken) {
-        useAuthStore.getState().setAccessToken(tokenResponse.result.accessToken);
-        return tokenResponse.result.accessToken;
+      const w = window as unknown as {
+        bridge?: { reissueAccessToken(): Promise<{ accessToken: string } | null> };
+      };
+      if (!w.bridge?.reissueAccessToken) return null;
+
+      const result = await w.bridge.reissueAccessToken();
+      if (result?.accessToken) {
+        useAuthStore.getState().setAccessToken(result.accessToken);
+        return result.accessToken;
       }
       return null;
-    } catch (error) {
-      console.error('[API] Token refresh failed:', error);
+    } catch {
       useAuthStore.getState().clearAuth();
       if (typeof window !== 'undefined') {
         window.location.href = '/login';
@@ -41,13 +44,27 @@ const refreshAccessToken = async (): Promise<string | null> => {
   return refreshPromise;
 };
 
+/** API 로그: 엔드포인트, 액세스/리프레시 토큰 유무, 응답 상태 */
+const logApi = (request: Request, response: Response | undefined) => {
+  const endpoint = request.url.replace(API_BASE_URL, '') || request.url;
+  const hasAccess = !!request.headers.get('Authorization');
+  const hasRefresh = !!request.headers.get('RefreshToken');
+  const status = response?.status ?? '-';
+  console.log(
+    '[API]\n' +
+      `1. API 요청 엔드포인트: ${endpoint}\n` +
+      `2. 액세스토큰: ${hasAccess ? '있음' : '없음'}\n` +
+      `3. 리프레쉬토큰: ${hasRefresh ? '있음' : '없음'}\n` +
+      `4. 응답 상태 코드: ${status}`
+  );
+};
+
 /**
  * 인증이 필요 없는 기본 API 클라이언트
  */
 export const apiClient = ky.create({
   prefixUrl: API_BASE_URL,
   timeout: API_TIMEOUT,
-  credentials: 'include',
   headers: {
     'Content-Type': 'application/json',
   },
@@ -56,60 +73,76 @@ export const apiClient = ky.create({
     methods: ['get'],
     statusCodes: [408, 429, 500, 502, 503, 504],
   },
+  hooks: {
+    beforeError: [
+      async (error) => {
+        if (error.request instanceof Request) {
+          logApi(error.request, error.response);
+        }
+        if (error.response) {
+          try {
+            const body = await error.response.text();
+            error.message = `${error.message}: ${body}`;
+          } catch {
+            // 응답 본문 읽기 실패 시 무시
+          }
+        }
+        return error;
+      },
+    ],
+  },
 });
 
 /**
  * 인증이 필요한 API 클라이언트
  *
  * - Access Token을 Authorization 헤더에 자동 추가
- * - Refresh Token은 HttpOnly Cookie로 자동 전송
  * - 401 에러 시 자동으로 토큰 갱신 시도
  */
+type KyContext = { retriedAfterRefresh?: boolean };
+
 export const authenticatedApiClient = apiClient.extend({
-  credentials: 'include',
-  retry: {
-    limit: API_RETRY_LIMIT,
-    backoffLimit: API_RETRY_BACKOFF_LIMIT,
-    statusCodes: [408, 429, 500, 502, 503, 504],
-  },
   hooks: {
-    // 요청 전 Authorization 헤더에 Access Token 추가
     beforeRequest: [
       (request) => {
-        if (typeof window === 'undefined') return;
-
         const accessToken = useAuthStore.getState().accessToken;
-        if (accessToken) {
+        if (accessToken && accessToken !== 'invalid') {
           request.headers.set('Authorization', `Bearer ${accessToken}`);
         }
       },
     ],
 
-    // 에러 발생 시 응답 본문을 에러 메시지에 추가
-    beforeError: [
-      async (error) => {
-        if (error.response) {
-          try {
-            const body = await error.response.text();
-            error.message = `${error.message}: ${body}`;
-          } catch {
-            // 응답 본문을 읽을 수 없는 경우 무시
-          }
-        }
-        return error;
-      },
-    ],
-
-    // 401 에러 발생 시 토큰 갱신 후 재시도
     afterResponse: [
-      async (request, _options, response) => {
-        if (response.status === 401 || response.status === 403) {
-          const newToken = await refreshAccessToken();
+      async (request, options, response) => {
+        if (typeof window !== 'undefined') {
+          logApi(request, response);
+        }
 
-          if (newToken) {
-            request.headers.set('Authorization', `Bearer ${newToken}`);
-            return ky(new Request(request));
+        const ctx = (options.context ?? {}) as KyContext;
+
+        // 401/403이면 네이티브 reissue 호출 → 토큰 갱신 → 원요청 1회 재시도
+        if ((response.status === 401 || response.status === 403) && !ctx.retriedAfterRefresh) {
+          const newToken = await refreshAccessToken();
+          if (!newToken) {
+            useAuthStore.getState().clearAuth();
+            if (typeof window !== 'undefined') {
+              window.location.href = '/login';
+            }
+            return response;
           }
+
+          ctx.retriedAfterRefresh = true;
+
+          // options.headers 기반으로 갱신해서 재시도 (request.headers를 직접 건드리면 꼬일 수 있음)
+          const nextHeaders = new Headers(options.headers ?? request.headers);
+          nextHeaders.set('Authorization', `Bearer ${newToken}`);
+
+          // 같은 인스턴스로 재요청
+          return authenticatedApiClient(request, {
+            ...options,
+            headers: nextHeaders,
+            context: ctx,
+          });
         }
 
         return response;

--- a/apps/web/src/shared/api/endpoint.ts
+++ b/apps/web/src/shared/api/endpoint.ts
@@ -3,7 +3,6 @@ export const ENDPOINT = {
   AUTH: {
     KAKAO_LOGIN: 'api/auth/kakao/login',
     REISSUE: 'api/auth/reissue',
-    LOGOUT: 'api/auth/logout',
     WITHDRAW: 'api/auth/withdraw',
     TERMS: 'api/auth/terms',
   },

--- a/apps/web/src/shared/lib/auth/AuthGuard.tsx
+++ b/apps/web/src/shared/lib/auth/AuthGuard.tsx
@@ -6,30 +6,40 @@ import { useAuthStore } from '@/shared/stores/authStore';
 import { useNativeAuth } from '@/shared/lib/bridge';
 
 /**
- * 인증 가드 컴포넌트
- * 토큰이 없으면 로그인 페이지로 리다이렉트
+ * 인증 가드
+ * - 토큰 없을 때: WebView(브릿지 있음)면 리다이렉트 안 함 → 401 나면 reissue 시도, 실패 시에만 로그인으로
+ * - 브라우저/브릿지 없음: 토큰 없으면 바로 로그인으로
  */
 export const AuthGuard = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
   const pathname = usePathname();
   const accessToken = useAuthStore((state) => state.accessToken);
 
-  // 네이티브 앱에서 토큰 자동 로드
   useNativeAuth();
 
   useEffect(() => {
-    // 로그인 페이지나 인증 콜백 페이지는 체크하지 않음
     const publicPaths = ['/login', '/auth'];
     const isPublicPath = publicPaths.some((path) => pathname.startsWith(path));
 
-    if (isPublicPath) {
-      return;
-    }
+    if (isPublicPath) return;
+    if (accessToken) return;
 
-    // 토큰이 없으면 로그인 페이지로 리다이렉트
-    if (!accessToken) {
+    const hasReissueBridge = () =>
+      typeof window !== 'undefined' &&
+      !!(window as unknown as { bridge?: { reissueAccessToken?: unknown } }).bridge
+        ?.reissueAccessToken;
+
+    // WebView(브릿지 있음): 토큰 없어도 리다이렉트 안 함 → 요청 시 401 → reissue 시도, 실패 시 client에서 로그인으로
+    if (hasReissueBridge()) return;
+
+    // 브릿지가 아직 없을 수 있음(초기화 중) → 잠시 후 재확인, 그래도 없고 토큰도 없으면 로그인으로
+    const t = window.setTimeout(() => {
+      if (useAuthStore.getState().accessToken) return;
+      if (hasReissueBridge()) return;
       router.replace('/login');
-    }
+    }, 1500);
+
+    return () => clearTimeout(t);
   }, [accessToken, pathname, router]);
 
   return <>{children}</>;

--- a/apps/web/src/shared/lib/bridge/bridge-setup.ts
+++ b/apps/web/src/shared/lib/bridge/bridge-setup.ts
@@ -3,23 +3,31 @@
 import { linkBridge } from '@webview-bridge/web';
 import type { AppBridge } from '@repo/bridge';
 
+const BRIDGE_RETRY_COUNT = 5;
+const BRIDGE_RETRY_DELAY_MS = 500;
+
 /**
- * 웹뷰 브릿지 초기화
+ * 웹뷰 브릿지 초기화 (재시도 포함)
  * 네이티브 앱의 브릿지와 웹을 연결
  */
-export const initializeBridge = () => {
+export const initializeBridge = async (): Promise<void> => {
   if (typeof window === 'undefined') return;
 
-  try {
-    // 브릿지 연결
-    const bridge = linkBridge({
-      throwOnError: true,
-      timeout: 1000 * 60 * 10, // 10분
-    }) as unknown as AppBridge;
+  for (let i = 0; i < BRIDGE_RETRY_COUNT; i++) {
+    try {
+      const bridge = linkBridge({
+        throwOnError: true,
+        timeout: 10_000,
+      }) as unknown as AppBridge;
 
-    // window 객체에 브릿지 저장
-    (window as unknown as { bridge: AppBridge }).bridge = bridge;
-  } catch {
-    // 브릿지 초기화 실패 (웹 환경)
+      (window as unknown as { bridge: AppBridge }).bridge = bridge;
+      console.log('[WEB] bridge ready');
+      return;
+    } catch (e) {
+      console.warn('[WEB] linkBridge failed', i + 1, e);
+      if (i < BRIDGE_RETRY_COUNT - 1) {
+        await new Promise((r) => setTimeout(r, BRIDGE_RETRY_DELAY_MS));
+      }
+    }
   }
 };

--- a/apps/web/src/shared/lib/bridge/useNativeAuth.ts
+++ b/apps/web/src/shared/lib/bridge/useNativeAuth.ts
@@ -11,22 +11,17 @@ import { getPlatform } from '@/shared/utils';
 export const useNativeAuth = () => {
   const bridge = useBridge();
   const platform = getPlatform();
-  const setAuth = useAuthStore((state) => state.setAuth);
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
 
   useEffect(() => {
     const loadNativeTokens = async () => {
-      // 웹뷰 환경에서만 실행
+      // 웹뷰 환경에서만 실행 (accessToken만 동기화, refreshToken은 덮어쓰지 않음)
       if ((platform === 'ios' || platform === 'android') && bridge) {
         try {
-          const { accessToken } = await bridge.getAccessToken();
+          const accessToken = await bridge.getAccessToken();
 
           if (accessToken) {
-            // 네이티브에 저장된 토큰을 웹 스토어에 동기화
-            setAuth({
-              accessToken,
-              // TODO: RefreshToken 사용 시 주석 해제
-              // refreshToken: refreshToken || '',
-            });
+            setAccessToken(accessToken);
           }
         } catch {
           // 토큰 로드 실패
@@ -35,5 +30,5 @@ export const useNativeAuth = () => {
     };
 
     loadNativeTokens();
-  }, [bridge, platform, setAuth]);
+  }, [bridge, platform, setAccessToken]);
 };

--- a/apps/web/src/shared/stores/authStore.ts
+++ b/apps/web/src/shared/stores/authStore.ts
@@ -1,47 +1,49 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 interface AuthState {
   accessToken: string | null;
-  // TODO: RefreshToken 사용 시 주석 해제
-  // refreshToken: string | null;
   setAccessToken: (accessToken: string) => void;
-  setAuth: (tokens: { accessToken: string; refreshToken?: string }) => void;
   clearAuth: () => void;
 }
 
 /**
+ * SSR/WebView 안전한 storage
+ * - 서버: localStorage 없음 → no-op
+ * - 클라이언트/WebView: localStorage 사용
+ */
+const authStorage = createJSONStorage<Partial<AuthState>>(() => {
+  if (typeof window === 'undefined') {
+    return {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+  }
+  return localStorage;
+});
+
+/**
  * 인증 상태 관리 스토어
- *  */
+ * - persist: localStorage에 저장 (Next.js/WebView에서 skipHydration으로 hydration 오류 방지)
+ */
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       accessToken: null,
-      // TODO: RefreshToken 사용 시 주석 해제
-      // refreshToken: null,
 
       setAccessToken: (accessToken) => {
         set({ accessToken });
       },
 
-      setAuth: (tokens) => {
-        set({
-          accessToken: tokens.accessToken,
-          // TODO: RefreshToken 사용 시 주석 해제
-          // refreshToken: tokens.refreshToken
-        });
-      },
-
       clearAuth: () => {
-        set({
-          accessToken: null,
-          // TODO: RefreshToken 사용 시 주석 해제
-          // refreshToken: null
-        });
+        set({ accessToken: null });
       },
     }),
     {
       name: 'auth-storage',
+      storage: authStorage,
+      skipHydration: true,
     }
   )
 );

--- a/apps/web/src/shared/utils/clearUserStorage.ts
+++ b/apps/web/src/shared/utils/clearUserStorage.ts
@@ -1,0 +1,23 @@
+import { useAuthStore } from '@/shared/stores/authStore';
+
+/** 앱에서 사용하는 persist/로컬 스토리지 키 (회원 탈퇴·로그아웃 시 비우기용) */
+export const USER_STORAGE_KEYS = [
+  'auth-storage',
+  'onboarding/status',
+  'expense-form-storage',
+  'category-storage',
+  'category-management-onboarding-completed',
+] as const;
+
+/**
+ * 인증 상태 + 모든 사용자 관련 스토리지 비우기
+ * (회원 탈퇴 성공 시 또는 로그아웃 시 사용)
+ */
+export const clearAllUserStorage = (): void => {
+  if (typeof window === 'undefined') return;
+
+  useAuthStore.getState().clearAuth();
+  for (const key of USER_STORAGE_KEYS) {
+    localStorage.removeItem(key);
+  }
+};

--- a/apps/web/src/shared/utils/index.ts
+++ b/apps/web/src/shared/utils/index.ts
@@ -2,3 +2,4 @@ export { getTextWidth } from './getTextWidth';
 export { normalizeNumberValue, formatNumberWithComma } from './inputFormatters';
 export { formatDate, formatDateToISO } from './date';
 export { getPlatform } from './getPlatform';
+export { clearAllUserStorage, USER_STORAGE_KEYS } from './clearUserStorage';

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -36,8 +36,14 @@ export type AppBridge = {
   // 소셜 로그인
   socialLogin: (type: 'kakao' | 'apple') => Promise<SocialLoginResult>;
 
-  // 토큰 관리
-  getAccessToken: () => Promise<{ accessToken: string | null }>;
+  // 토큰 관리 (accessToken만 노출, reissue는 reissueAccessToken()만 사용)
+  getAccessToken: () => Promise<string | null>;
+
+  /**
+   * reissue: 리프레시토큰으로 새 액세스·리프레시 둘 다 발급받아 네이티브에 저장.
+   * 웹에는 새 accessToken만 반환 (리프레시는 웹에 노출 안 함).
+   */
+  reissueAccessToken: () => Promise<{ accessToken: string } | null>;
 
   // 로그아웃
   requestLogout: () => Promise<void>;

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,8 @@
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^lint"],
+      "env": ["NODE_ENV"]
     },
     "check-types": {
       "dependsOn": ["^check-types"]


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #120

## ✅ 작업 목록

### 1. 카카오 로그인 백엔드 API 스펙 정합

- **기존**: 네이티브에서 카카오 `me()`로 사용자 정보(id, nickname 등)를 조회한 뒤, 그 객체를 그대로 백엔드 `POST /api/auth/kakao/login`에 전송.
- **변경**: 백엔드가 기대하는 형식에 맞춰 **카카오 `accessToken`만** 전달하도록 수정.
  - 요청 body: `{ accessToken: kakaoResult.accessToken }`
  - 카카오 사용자 정보 조회(`me()`) 및 변환 로직 제거 → 백엔드에서 토큰 검증 및 사용자 생성/조회 담당.

### 2. 리이슈(토큰 재발급) 아키텍처 정리 — 웹에 refreshToken 미노출

- **보안**: 웹(WebView)에는 **accessToken만** 노출하고, refreshToken은 네이티브(SecureStore)에만 보관.
- **네이티브** (`apps/mobile/shared/lib/bridge.ts`):
  - `getAccessToken()`: 반환 타입을 `Promise<{ accessToken: string | null }>` → `Promise<string | null>`로 변경. accessToken만 반환.
  - **신규** `reissueAccessToken()`:  
    - SecureStore의 refreshToken으로 `POST /api/auth/reissue` (헤더 `RefreshToken`) 호출.  
    - 새 access·refresh 토큰을 네이티브에 저장하고, 웹에는 **새 accessToken만** 반환 `{ accessToken: string }`.
- **웹** (`apps/web/src/shared/api/client.ts`):
  - 401 시 웹에서 `/api/auth/reissue` 직접 호출 제거.
  - `refreshAccessToken()`에서 `window.bridge?.reissueAccessToken()`만 호출 → 네이티브가 reissue 수행 후 새 accessToken 반환 → 웹은 `authStore.setAccessToken()` 후 재시도만 수행.

### 3. 웹 authStore 단순화 및 persist 안전 처리

- **파일**: `apps/web/src/shared/stores/authStore.ts`
- `setAuth()`, `refreshToken` 상태 제거. **accessToken만** 관리.
- `persist` 설정:
  - `createJSONStorage`로 SSR/WebView 대응: `typeof window === 'undefined'`일 때 no-op 스토리지 사용.
  - `skipHydration: true`로 Next/WebView hydration 이슈 방지.
- Providers에서 `useAuthStore.persist.rehydrate()` 호출로 클라이언트 측 복원 보장.

### 4. 401/403 시 재시도 로직 보강 (웹 API 클라이언트)

- **파일**: `apps/web/src/shared/api/client.ts`
- **재시도 1회 제한**: `KyContext`에 `retriedAfterRefresh` 플래그 도입 → reissue 후 재요청은 한 번만 수행해 무한 루프 방지.
- **재요청 방식**: `request.headers` 직접 수정 대신 `options.headers`를 복사한 `nextHeaders`에 새 토큰 설정 후 `authenticatedApiClient(request, { ...options, headers: nextHeaders, context })`로 재요청.
- **실패 시**: reissue 실패 또는 브릿지 없음 시 `clearAuth()` 후 `/login`으로 리다이렉트.
- **로깅**: `logApi()`로 엔드포인트·액세스/리프레시 토큰 유무·응답 상태 코드 출력 (디버깅용).
- Authorization 헤더는 `accessToken`이 있고 `!== 'invalid'`일 때만 붙이도록 조건 정리.

### 5. AuthGuard 동작 정리 (WebView vs 브라우저)
- **파일**: `apps/web/src/shared/lib/auth/AuthGuard.tsx`
- **WebView(브릿지 있음)**: 토큰이 없어도 즉시 로그인으로 리다이렉트하지 않음. 첫 API 요청 시 401 → reissue 시도 → 실패 시에만 client에서 `/login` 이동.
- **브라우저(브릿지 없음)**: 토큰 없으면 로그인 페이지로 리다이렉트.
- 브릿지 초기화 지연 고려: 토큰 없고 `reissueAccessToken` 브릿지도 없을 때 **약 1.5초 대기** 후 다시 확인, 그래도 없으면 `/login`으로 이동.

### 6. 브릿지 초기화 재시도 (웹)
- **파일**: `apps/web/src/shared/lib/bridge/bridge-setup.ts`
- `initializeBridge()`를 async로 변경, 실패 시 최대 5회 재시도 (간격 500ms).
- 타임아웃 10분 → 10초로 단축.
- 성공 시 `[WEB] bridge ready` 로그.

### 7. 웹에서 네이티브 토큰 동기화
- **파일**: `SocialLoginButtons.tsx`, `useNativeAuth.ts`
- `setAuth` 제거, `setAccessToken`만 사용.
- `bridge.getAccessToken()` 반환값을 `string | null`로 처리하도록 호출부 수정.

### 기타

- **Mobile** `app/index.tsx`: WebView 쿠키 옵션(`sharedCookiesEnabled`, `thirdPartyCookiesEnabled`) 제거. `initialUrl` setter 미사용으로 불필요한 `setInitialUrl` 제거.
- **turbo.json**: `lint` 태스크에 `env: ["NODE_ENV"]` 추가.

---

**참고 정리!**

- 카카오 로그인 플로우는 **네이티브에서만** 카카오 SDK + 백엔드 호출 + 토큰 저장까지 수행하고, 웹은 `bridge.socialLogin('kakao')` 결과로 받은 accessToken만 사용합니다.
- 401 처리는 **웹 → bridge.reissueAccessToken() → 네이티브 reissue → 새 accessToken 반환 → 웹 스토어 갱신 후 1회 재시도**로만 이루어지며, 웹에는 refreshToken이 전혀 노출되지 않습니다.
- `AuthGuard`의 1.5초 지연은 WebView 로드 직후 브릿지가 아직 주입되지 않은 경우를 위한 것이므로, 필요 시 상수로 분리해 조정 가능합니다.

## 🍰 논의사항

1. **AuthGuard 1.5초 대기**: WebView에서 브릿지 준비 전에 AuthGuard가 실행되는 경우를 위한 값입니다. 실제 기기/환경에서 부족하거나 과한지 확인 필요할 듯...
2. **API 로그 (`logApi`)**: 현재 `console.log`로 남기고 있습니다. 배포 빌드에서는 로그 레벨 제거 또는 조건부 출력 검토 필요..
3. **reissue 실패 시 로그인 리다이렉트**: `client.ts`와 `refreshAccessToken()` 내부 모두에서 `clearAuth()` 후 `/login` 이동을 하고 있습니다. 한 곳으로 통일할지, 아니면 현재처럼 방어적으로 두 곳에서 처리할지....

## 📷 ETC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 로그아웃/탈퇴 시 상태 정리 및 오류 처리 개선
  * 토큰 재발급 실패 시 로그인 리다이렉션 오류 완화

* **개선사항**
  * 네이티브 기반 토큰 재발급 연동 및 401/403 자동 재시도 도입
  * 브리지 초기화 재시도 및 토큰 동기화 안정화
  * 웹 저장소 SSR/웹뷰 호환성 강화

* **리팩토링**
  * 인증 상태 단순화(액세스 토큰 중심) 및 관련 호출 정리

* **신규**
  * 클라이언트측 사용자 데이터 일괄 삭제 유틸 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->