### PR TITLE
Fix: 고정 카테고리 버그 수정

### DIFF
--- a/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
@@ -44,6 +44,7 @@ export const ExpenseEditBottomSheet = ({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [isCategorySheetOpen, setIsCategorySheetOpen] = useState(false);
+  const [frontCategoryId, setFrontCategoryId] = useState<string | null>(null);
   const [date, setDate] = useState<Date>(initialDate);
 
   const [amountError, setAmountError] = useState<string | undefined>(undefined);
@@ -113,6 +114,7 @@ export const ExpenseEditBottomSheet = ({
         const matchedCategory = categories.find((c) => c.name === expense.categoryName);
         if (matchedCategory) {
           setSelectedCategoryId(String(matchedCategory.id));
+          setFrontCategoryId(String(matchedCategory.id));
         }
       }
     }
@@ -179,8 +181,8 @@ export const ExpenseEditBottomSheet = ({
       label: cat.name ?? '',
     }));
 
-    if (selectedCategoryId) {
-      const selectedIndex = list.findIndex((c) => c.id === selectedCategoryId);
+    if (frontCategoryId) {
+      const selectedIndex = list.findIndex((c) => c.id === frontCategoryId);
       if (selectedIndex > 0) {
         const selected = list[selectedIndex];
         if (selected) {
@@ -190,7 +192,7 @@ export const ExpenseEditBottomSheet = ({
     }
 
     return list;
-  }, [categories, selectedCategoryId]);
+  }, [categories, frontCategoryId]);
 
   return (
     <BottomSheet isOpen={isOpen} onClose={onClose}>
@@ -241,6 +243,7 @@ export const ExpenseEditBottomSheet = ({
           selectedId={selectedCategoryId}
           onSelect={(category) => {
             setSelectedCategoryId(category.id);
+            setFrontCategoryId(category.id);
             setIsCategorySheetOpen(false);
           }}
           onConfirm={() => setIsCategorySheetOpen(false)}


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

- close #124 

## ✅ 작업 목록
- ExpenseEditBottomSheet 내에서 카테고리 선택시 순서가 계속 바뀌는 버그를 수정
formattedCategories가 selectedCategoryId에 의존하고 있어서, 인라인 카테고리 그리드에서 카테고리를 선택할 때도 순서가 변경되는 버그가 있었습니다. 

- frontCategoryId state를 별도로 추가하여 "맨 앞에 배치할 카테고리"를 분리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 지출 편집 시 카테고리 선택의 일관성을 개선했습니다.
  * 카테고리 선택 상태가 카테고리 시트 열기 시 더 정확하게 동기화되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->