### PR TITLE
Bug:  지출 내역 작성, 로그아웃 이후 등 캐시 무효화

### DIFF
--- a/apps/web/src/entities/expense/model/queries.ts
+++ b/apps/web/src/entities/expense/model/queries.ts
@@ -2,6 +2,12 @@ import { queryOptions } from '@tanstack/react-query';
 import { getDailyExpense } from '../api/getDailyExpense';
 import { getExpenseCalendar } from '../api/getExpenseCalendar';
 
+/**
+ * 지출 관련 쿼리 키 설계
+ * - all: invalidation 시 일일/캘린더 전체 무효화에 사용
+ * - dailyExpense(date): 날짜별 → 선택일 변경 시 자동 refetch
+ * - calendarExpense(year, month): 월별 → 연·월 변경 시 자동 refetch
+ */
 export const expenseQueries = {
   all: ['expense'] as const,
   dailyExpense: (date: Date) =>

--- a/apps/web/src/entities/expenseReport/model/queries.ts
+++ b/apps/web/src/entities/expenseReport/model/queries.ts
@@ -1,6 +1,11 @@
 import { queryOptions } from '@tanstack/react-query';
 import { getSummaryRecord } from '../api/getSummaryRecord';
 
+/**
+ * 요약/리포트 쿼리 키 설계
+ * - summary: 이번 달 총액 등(서버가 현재 월 기준 반환). 월 파라미터 없음.
+ * - 지출 작성/수정/삭제·로그아웃 시 invalidate 또는 clear 필요.
+ */
 export const expenseReportQueries = {
   all: ['expenseReport'] as const,
   summaryQuery: () =>

--- a/apps/web/src/features/auth/model/useLogout.ts
+++ b/apps/web/src/features/auth/model/useLogout.ts
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/shared/ui';
 import { useBridge } from '@/shared/lib/bridge';
 import { clearAllUserStorage, getPlatform } from '@/shared/utils';
@@ -10,6 +11,7 @@ import { clearAllUserStorage, getPlatform } from '@/shared/utils';
 export const useLogout = () => {
   const router = useRouter();
   const toast = useToast();
+  const queryClient = useQueryClient();
   const bridge = useBridge();
   const platform = getPlatform();
   const [isPending, setIsPending] = useState(false);
@@ -25,6 +27,8 @@ export const useLogout = () => {
         }
       }
       clearAllUserStorage();
+      // 이전 사용자 월별/요약 등 모든 쿼리 캐시 제거 (로그인 후 다른 사용자 데이터 노출 방지)
+      queryClient.clear();
       toast.success('로그아웃이 완료되었어요');
       router.replace('/login');
     } catch {
@@ -32,7 +36,7 @@ export const useLogout = () => {
     } finally {
       setIsPending(false);
     }
-  }, [bridge, platform, toast, router]);
+  }, [bridge, platform, toast, router, queryClient]);
 
   return { handleLogout, isPending };
 };

--- a/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
@@ -16,7 +16,13 @@ import {
   deleteExpense,
   type UpdateExpenseRequest,
 } from '@/features/expense/model';
-import { EXPENSE_CONSTANTS, EXPENSE_ERROR_MESSAGES, type ExpenseListDTO } from '@/entities/expense';
+import {
+  EXPENSE_CONSTANTS,
+  EXPENSE_ERROR_MESSAGES,
+  expenseQueries as entityExpenseQueries,
+  type ExpenseListDTO,
+} from '@/entities/expense';
+import { expenseReportQueries } from '@/entities/expenseReport';
 
 export interface ExpenseEditBottomSheetProps {
   isOpen: boolean;
@@ -64,10 +70,8 @@ export const ExpenseEditBottomSheet = ({
     mutationFn: ({ expenseId, data }: { expenseId: number; data: UpdateExpenseRequest }) =>
       updateExpense(expenseId, data),
     onSuccess: () => {
-      // 일일 지출 데이터 캐시 무효화하여 리페칭
-      queryClient.invalidateQueries({ queryKey: ['expense', 'daily'] });
-      // 월별 지출 데이터 캐시 무효화하여 리페칭 (Summary Record)
-      queryClient.invalidateQueries({ queryKey: ['expenseReport', 'summary'] });
+      queryClient.invalidateQueries({ queryKey: entityExpenseQueries.all });
+      queryClient.invalidateQueries({ queryKey: expenseReportQueries.all });
       toast.success('소비 기록이 수정되었어요.');
       onConfirm?.({
         ...expense!,
@@ -85,10 +89,8 @@ export const ExpenseEditBottomSheet = ({
   const deleteMutation = useMutation({
     mutationFn: (expenseId: number) => deleteExpense(expenseId),
     onSuccess: () => {
-      // 일일 지출 데이터 캐시 무효화하여 리페칭
-      queryClient.invalidateQueries({ queryKey: ['expense', 'daily'] });
-      // 월별 지출 데이터 캐시 무효화하여 리페칭 (Summary Record)
-      queryClient.invalidateQueries({ queryKey: ['expenseReport', 'summary'] });
+      queryClient.invalidateQueries({ queryKey: entityExpenseQueries.all });
+      queryClient.invalidateQueries({ queryKey: expenseReportQueries.all });
       toast.success('소비 기록이 삭제되었어요.');
       if (expense?.expenseId) {
         onDelete?.(expense.expenseId);

--- a/apps/web/src/widgets/expenseRecordFunnel/ui/ExpenseRecordFunnel.tsx
+++ b/apps/web/src/widgets/expenseRecordFunnel/ui/ExpenseRecordFunnel.tsx
@@ -18,7 +18,9 @@ import { IcLeftChevron } from 'public/icons';
 import { AmountDateStep, SatisfactionStep, UsageCategoryStep } from '@/features/expense/ui/steps';
 import { expenseQueries } from '@/features/expense/model/expenseQueries';
 import type { EmotionType } from '@/features/expense/model/types';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { expenseReportQueries } from '@/entities/expenseReport';
+import { expenseQueries as entityExpenseQueries } from '@/entities/expense';
 import { ROUTES } from '@/shared/constants';
 
 const STEP_NUMBER = {
@@ -31,6 +33,7 @@ const STEP_NUMBER = {
 export const ExpenseRecordFunnel = () => {
   const router = useRouter();
   const toast = useToast();
+  const queryClient = useQueryClient();
   const { isOpen, openModal, closeModal } = useModal();
   const formStore = useExpenseFormStore();
   const funnel = useFunnel<{
@@ -88,6 +91,9 @@ export const ExpenseRecordFunnel = () => {
       },
       {
         onSuccess: () => {
+          // 월별/일일 지출·요약 캐시 무효화 → 이번 달 지출 금액 등 즉시 반영
+          queryClient.invalidateQueries({ queryKey: entityExpenseQueries.all });
+          queryClient.invalidateQueries({ queryKey: expenseReportQueries.all });
           formStore.reset();
           toast.success('소비 기록이 저장되었어요.');
           router.push(ROUTES.HOME);


### PR DESCRIPTION
## 📝 PR 유형

* [ ] 🚀 feature 기능 추가
* [x] 🐞 버그 발생
* [x] 🔨 리팩토링
* [x] 📋 문서작성
* [ ] 🌍 빌드 설정 및 문제
* [ ] ETC

## 🔔 관련된 이슈 넘버

close #127 

## ✅ 작업 목록

### 1) 지출 작성 성공 시 캐시 무효화 (홈 요약 즉시 갱신)

* 대상 파일: `apps/web/src/widgets/expenseRecordFunnel/ui/ExpenseRecordFunnel.tsx`
* 변경 내용

  * `useQueryClient` 추가.
  * 지출 기록 저장 성공(onSuccess) 시 아래 캐시를 무효화하도록 처리.

    * `entityExpenseQueries.all`

      * 일일 지출(daily) / 캘린더 지출(calendar) 관련 쿼리 전부 포함
    * `expenseReportQueries.all`

      * 홈 상단 “이번 달 지출 n원” 요약 쿼리 포함
* 효과

  * 지출 추가 후 홈으로 돌아갔을 때 “이번 달 지출 n원”이 즉시 최신 값으로 갱신됨.
  * 일일/캘린더 화면도 동일하게 최신 상태 보장.


### 2) 로그아웃 시 캐시 초기화 (이전 사용자 데이터 잔존 방지)

* 대상 파일: `apps/web/src/features/auth/model/useLogout.ts`
* 변경 내용

  * `useQueryClient` 사용.
  * `clearAllUserStorage()` 호출 직후 `queryClient.clear()` 호출 추가.
* 효과

  * 로그아웃 시 React Query 캐시 전체를 비워서,
    다음 로그인 사용자의 월별/요약 데이터가 이전 사용자 값으로 남는 문제를 방지.
  * “사용자 전환 시 캐시 오염”을 구조적으로 차단.

---

### 3) 수정/삭제 시 캐시 무효화 정책 통일 (일일만 갱신되던 문제 개선)

* 대상 파일: `apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx`
* 기존 문제

  * 수정/삭제 성공 시 **일일만** 무효화하던 로직이 있어,
    캘린더/요약(이번 달 지출 n원) 데이터는 화면에 남아 불일치가 발생할 수 있었음.
* 변경 내용

  * 수정/삭제 성공 시에도 아래를 “전체 무효화”로 통일.

    * `entityExpenseQueries.all` → 일일/캘린더 전체
    * `expenseReportQueries.all` → 요약 전체
  * 기존 `['expense']`, `['expenseReport']` 같은 임의 키 사용 대신,
    `entities` 레이어의 `expenseQueries.all`, `expenseReportQueries.all`로 일원화.
* 효과

  * 지출 수정/삭제 후에도 **일일/캘린더/요약이 동시에** 즉시 갱신되도록 보장.
  * 쿼리 키 규칙이 한 곳(entities)에서 관리되어 유지보수성 증가.

---

### 4) 쿼리 키 설계 정리 및 “월/날짜 변경 refetch” 검증 + 문서화

* 검증 결과(월/날짜 변경 시 refetch 동작)

  * 일일: `dailyExpense(date)`

    * `date`가 쿼리 키에 포함 → 날짜 변경 시 키가 바뀌므로 **자동 refetch**.
  * 캘린더: `calendarExpense(year, month)`

    * `year`, `month`가 키에 포함 → 월 변경 시 키가 바뀌므로 **자동 refetch**.
  * 요약: `summaryQuery()`

    * 월 파라미터 없이 “이번 달 기준” 단일 쿼리
    * 월 변경만으로는 키가 바뀌지 않음 → 따라서 아래 시점에만 갱신 전략을 명확히 함

      * 지출 작성/수정/삭제 성공 시 `expenseReportQueries.all` 무효화
      * 로그아웃 시 `queryClient.clear()`로 초기화
* 문서화(JSDoc 추가)

  * 추가 내용

    * 각 쿼리 키의 용도
    * 연/월 포함 여부(월 단위 자동 refetch 가능 여부)
    * 어떤 액션에서 무효화/초기화가 필요한지(특히 요약 쿼리)

---

### 요약

* 지출 **추가/수정/삭제 후** → “이번 달 지출 n원” + 일일/캘린더가 즉시 갱신
* **로그아웃 후** → 이전 사용자 월별/요약 데이터 캐시가 남지 않음
* **월/날짜 변경 시** → 해당 일/월 쿼리 키 변경으로 자동 refetch

## 🍰 논의사항

* 요약 쿼리(`summaryQuery()`)가 “이번 달” 단일 키로 설계되어 있어,
  월 전환 UI에서 별도 갱신이 필요해질 가능성이 있는지 확인 필요.
  * 현재 정책: CRUD 시 무효화 + 로그아웃 시 clear로 충분하다는 전제

## 📷 ETC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 로그아웃 시 모든 캐시가 올바르게 초기화되어 데이터 일관성이 개선되었습니다.
  * 비용 항목 수정 및 삭제 시 캐시 무효화 범위가 확대되어 더욱 안정적인 데이터 동기화가 가능해졌습니다.

* **설명서**
  * 내부 쿼리 키 설계 및 캐시 관리 동작에 대한 문서를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->