### PR TITLE
Fix: WebView 브릿지 지연으로 인한 카카오·Apple 로그인 오류 수정

### DIFF
--- a/apps/mobile/shared/lib/bridge.ts
+++ b/apps/mobile/shared/lib/bridge.ts
@@ -163,7 +163,6 @@ export type AppBridgeType = typeof appBridge;
 export const { WebView } = createWebView({
   bridge: appBridge,
   debug: __DEV__,
-  timeout: 120000, // 2분 타임아웃 (카카오 로그인 대기 시간 고려)
   fallback: (method) => {
     console.warn(`[Bridge] Method '${method}' not found in native`);
   },

--- a/apps/mobile/social/useAppleLogin.ts
+++ b/apps/mobile/social/useAppleLogin.ts
@@ -2,15 +2,46 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 import { postAppleLogin } from '@/apis/postAppleLogin';
 import type { ApiResponse, LoginData } from '@/shared/types/api.types';
 
+function getAppleAuthErrorMessage(error: unknown): string {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as { code?: string }).code;
+    switch (code) {
+      case 'ERR_REQUEST_CANCELED':
+        return '로그인이 취소되었습니다.';
+      case 'ERR_REQUEST_NOT_HANDLED':
+        return 'Apple 로그인을 처리할 수 없습니다.';
+      case 'ERR_REQUEST_FAILED':
+        return 'Apple 로그인 요청이 실패했습니다.';
+      case 'ERR_REQUEST_NOT_INTERACTIVE':
+        return 'Apple 로그인 화면을 표시할 수 없습니다.';
+      case 'ERR_REQUEST_INVALID_RESPONSE':
+        return 'Apple 로그인 응답이 올바르지 않습니다.';
+      default:
+        break;
+    }
+  }
+  if (error instanceof Error) return error.message;
+  return 'Apple 로그인에 실패했습니다.';
+}
+
 export const useAppleLogin = async (): Promise<ApiResponse<LoginData>> => {
   try {
-    const appleResult = await AppleAuthentication.signInAsync({});
+    const appleResult = await AppleAuthentication.signInAsync({
+      requestedScopes: [
+        AppleAuthentication.AppleAuthenticationScope.EMAIL,
+        AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+      ],
+    });
     if (!appleResult.identityToken || !appleResult.authorizationCode) {
       throw new Error('애플로부터 토큰을 받지 못했습니다.');
     }
     const response = await postAppleLogin({ code: appleResult.authorizationCode });
     return response;
   } catch (error) {
-    throw error;
+    const message = getAppleAuthErrorMessage(error);
+    if (__DEV__) {
+      console.warn('[Apple Login]', error);
+    }
+    throw new Error(message);
   }
 };

--- a/apps/web/src/features/auth/model/useAppleLogin.ts
+++ b/apps/web/src/features/auth/model/useAppleLogin.ts
@@ -1,4 +1,5 @@
-import { useBridge } from '@/shared/lib/bridge';
+import type { AppBridge } from '@repo/bridge';
+import { useBridge, initializeBridge } from '@/shared/lib/bridge';
 import { getPlatform } from '@/shared/utils';
 
 interface AppleLoginData {
@@ -25,12 +26,22 @@ export const useAppleLogin = (options: AppleLoginOptions = {}): AppleLoginReturn
 
   const handleAppleLogin = async () => {
     try {
-      if (platform !== 'ios' || !bridge) {
+      if (platform !== 'ios') {
         onError?.(new Error('Apple 로그인은 iOS에서만 사용할 수 있습니다.'));
         return;
       }
+      // 브릿지가 아직 없으면 한 번 더 연결 시도 (실기기에서 준비 지연 시 대응)
+      let currentBridge = bridge;
+      if (!currentBridge && typeof window !== 'undefined') {
+        await initializeBridge();
+        currentBridge = (window as unknown as { bridge?: AppBridge }).bridge ?? null;
+      }
+      if (!currentBridge) {
+        onError?.(new Error('앱 연결에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
+        return;
+      }
 
-      const result = await bridge.socialLogin('apple');
+      const result = await currentBridge.socialLogin('apple');
 
       if (result.success) {
         onSuccess?.(result.data);

--- a/apps/web/src/features/auth/model/useKakaoLogin.ts
+++ b/apps/web/src/features/auth/model/useKakaoLogin.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
-import { useBridge } from '@/shared/lib/bridge';
+import type { AppBridge } from '@repo/bridge';
+import { useBridge, initializeBridge } from '@/shared/lib/bridge';
 import { getPlatform } from '@/shared/utils';
 
 interface KakaoLoginOptions {
@@ -26,16 +27,23 @@ export const useKakaoLogin = (options: KakaoLoginOptions = {}): KakaoLoginReturn
 
   const loginWithKakao = useCallback(async () => {
     try {
-      // 웹뷰 환경 (iOS/Android)에서는 브릿지를 통해 네이티브 로그인 사용
-      if ((platform === 'ios' || platform === 'android') && bridge) {
-        // 네이티브에서 모든 처리 완료 (카카오 로그인 + 백엔드 API + 토큰 저장)
-        const result = await bridge.socialLogin('kakao');
-
-        if (result.success) {
-          onSuccess?.();
-        } else {
-          onError?.(new Error(result.message || '카카오 로그인에 실패했습니다.'));
+      if (platform === 'ios' || platform === 'android') {
+        // 브릿지가 아직 없으면 한 번 더 연결 시도 (실기기에서 준비 지연 시 대응)
+        let currentBridge = bridge;
+        if (!currentBridge && typeof window !== 'undefined') {
+          await initializeBridge();
+          currentBridge = (window as unknown as { bridge?: AppBridge }).bridge ?? null;
         }
+        if (currentBridge) {
+          const result = await currentBridge.socialLogin('kakao');
+          if (result.success) {
+            onSuccess?.();
+          } else {
+            onError?.(new Error(result.message || '카카오 로그인에 실패했습니다.'));
+          }
+          return;
+        }
+        onError?.(new Error('앱 연결에 실패했습니다. 잠시 후 다시 시도해 주세요.'));
         return;
       }
 

--- a/apps/web/src/shared/lib/bridge/bridge-setup.ts
+++ b/apps/web/src/shared/lib/bridge/bridge-setup.ts
@@ -22,6 +22,7 @@ export const initializeBridge = async (): Promise<void> => {
 
       (window as unknown as { bridge: AppBridge }).bridge = bridge;
       console.log('[WEB] bridge ready');
+      window.dispatchEvent(new CustomEvent('bridge-ready'));
       return;
     } catch (e) {
       console.warn('[WEB] linkBridge failed', i + 1, e);

--- a/apps/web/src/shared/lib/bridge/useBridge.ts
+++ b/apps/web/src/shared/lib/bridge/useBridge.ts
@@ -23,13 +23,23 @@ export const useBridge = () => {
   });
 
   useEffect(() => {
-    // WebView 환경인지 확인
-    const isWebView = !!(window as unknown as { ReactNativeWebView?: unknown }).ReactNativeWebView;
-    const bridgeObj = (window as unknown as { bridge?: AppBridge }).bridge;
+    const win = typeof window === 'undefined' ? null : window;
+    if (!win) return;
+
+    const isWebView = !!(win as unknown as { ReactNativeWebView?: unknown }).ReactNativeWebView;
+    const bridgeObj = (win as unknown as { bridge?: AppBridge }).bridge;
 
     if (isWebView && bridgeObj) {
       setBridge(bridgeObj);
     }
+
+    // 브릿지가 나중에 준비되면(initializeBridge 완료) 갱신
+    const onBridgeReady = () => {
+      const b = (win as unknown as { bridge?: AppBridge }).bridge;
+      if (b) setBridge(b);
+    };
+    win.addEventListener('bridge-ready', onBridgeReady);
+    return () => win.removeEventListener('bridge-ready', onBridgeReady);
   }, []);
 
   return bridge;


### PR DESCRIPTION
## 📝 PR 유형

* [x] 🐞 버그 발생

## 🔔 관련된 이슈 넘버

close none

## ✅ 작업 목록

* 카카오 로그인 버튼 무반응 문제 수정

  * 원인: WebView–네이티브 브릿지 미연결 상태에서 클릭 시 동작 없음
  * initializeBridge 성공 시 `bridge-ready` 이벤트 발생
  * `useBridge`에서 이벤트 구독 후 브릿지 연결 상태 지연 반영
  * 버튼 클릭 시 bridge가 없으면 initializeBridge 재시도
  * 실패 시 사용자 안내 토스트 노출

* Apple 로그인 실패 UX 개선

  * 원인: 브릿지 연결 지연 + 에러 메시지 불명확
  * bridge 미존재 시 initializeBridge 재시도 로직 추가
  * expo-apple-authentication 에러 코드 → 사용자 메시지 매핑

    * `ERR_REQUEST_CANCELED` → "로그인이 취소되었습니다."
    * 기타 실패 → 구체적인 실패 안내 문구
  * requestedScopes에 `EMAIL`, `FULL_NAME` 명시

## 🍰 논의사항

* 브릿지 재시도 전략

  * 현재: 사용자 액션 시 1회 재시도
  * 추가 재시도 / 지연 대기 / fallback 처리 여부 검토 필요

* 토스트 문구 톤

  * 로그인 실패/취소 메시지 표현 통일 여부

## 📷 ETC

**카카오 로그인 관련 파일**

* apps/web/src/shared/lib/bridge/bridge-setup.ts
* apps/web/src/shared/lib/bridge/useBridge.ts
* apps/web/src/features/auth/model/useKakaoLogin.ts

**Apple 로그인 관련 파일**

* apps/web/src/features/auth/model/useAppleLogin.ts
* apps/mobile/social/useAppleLogin.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Apple 로그인이 사용자 조작으로 시작되는 새 흐름 지원(로그인 시작 버튼으로 동작).

* **버그 수정**
  * iOS 네이티브 연결 실패 시 사용자에게 명확한 오류 메시지 제공 및 실패 경로 개선.
  * Kakao 로그인 실패 처리 개선.

* **개선 사항**
  * iOS 앱 연결의 동적 초기화 및 재시도 지원으로 로그인 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->