### PR TITLE
Refactor: 소비기록 QA 피드백 반영

### DIFF
--- a/apps/mobile/apis/postKakaoLogin.ts
+++ b/apps/mobile/apis/postKakaoLogin.ts
@@ -1,24 +1,28 @@
 import { isAxiosError } from 'axios';
 import { baseAPI } from './instance';
-import type { ApiResponse, SocialLoginData } from '@/shared/types/api.types';
+import type { ApiResponse, LoginData } from '@/shared/types/api.types';
 
 export const postKakaoLogin = async ({
   accessToken,
 }: {
   accessToken: string;
-}): Promise<ApiResponse<SocialLoginData>> => {
+}): Promise<ApiResponse<LoginData>> => {
   try {
     const response = await baseAPI.post('/api/auth/kakao/login', { accessToken });
 
     const result = response.data?.result ?? response.data;
     const newAccessToken = result.accessToken ?? result.access_token;
     const newRefreshToken = result.refreshToken ?? result.refresh_token ?? '';
+    const { isNewUser, hasExpense, termsAgreed } = result;
 
     return {
       success: true,
       data: {
         accessToken: newAccessToken,
         refreshToken: newRefreshToken,
+        isNewUser,
+        hasExpense,
+        termsAgreed,
       },
     };
   } catch (error) {

--- a/apps/mobile/shared/lib/bridge.ts
+++ b/apps/mobile/shared/lib/bridge.ts
@@ -5,7 +5,7 @@ import { postKakaoLogin } from '@/apis/postKakaoLogin';
 import { postReissue } from '@/apis/postReissue';
 import { authStorage } from './authStorage';
 import { useAppleLogin } from '@/social/useAppleLogin';
-import type { ApiResponse, SocialLoginData } from '@/shared/types/api.types';
+import type { ApiResponse, LoginData } from '@/shared/types/api.types';
 import { onboardingStorage } from './onboardingStorage';
 
 /**
@@ -17,34 +17,36 @@ export const appBridge = bridge({
    * 소셜 로그인
    * 네이티브에서 카카오 로그인 → 백엔드 API 호출 → 토큰 저장까지 모두 처리
    */
-  async socialLogin(type: 'kakao' | 'apple'): Promise<ApiResponse<SocialLoginData>> {
+  async socialLogin(type: 'kakao' | 'apple'): Promise<ApiResponse<LoginData>> {
     try {
       if (type === 'kakao') {
         const kakaoResult = await login();
         const result = await postKakaoLogin({ accessToken: kakaoResult.accessToken });
-
+        console.log('socialLogin', result);
         if (!result.data?.accessToken) {
           throw new Error('백엔드 응답에 accessToken이 없습니다.');
         }
 
-        const { accessToken, refreshToken } = result.data;
+        const { accessToken, refreshToken, isNewUser, hasExpense, termsAgreed } = result.data;
         await authStorage.setTokens(accessToken, refreshToken ?? '');
 
         return {
           success: true,
-          data: { accessToken, refreshToken: refreshToken ?? '' },
+          data: {
+            accessToken,
+            refreshToken: refreshToken ?? '',
+            isNewUser: isNewUser,
+            hasExpense: hasExpense,
+            termsAgreed: termsAgreed,
+          },
         };
       } else if (type === 'apple') {
         const result = await useAppleLogin();
-        const accessToken = result.data?.accessToken;
-        const refreshToken = result.data?.refreshToken || null;
-        const isNewUser = result.data?.isNewUser;
-        const hasExpense = result.data?.hasExpense;
-        const termsAgreed = result.data?.termsAgreed;
 
-        if (!accessToken) {
+        if (!result.data?.accessToken) {
           throw new Error('애플 로그인 응답에 accessToken이 없습니다.');
         }
+        const { accessToken, refreshToken, isNewUser, hasExpense, termsAgreed } = result.data;
 
         await authStorage.setTokens(accessToken, refreshToken || '');
 
@@ -58,9 +60,9 @@ export const appBridge = bridge({
           data: {
             accessToken,
             refreshToken: refreshToken || '',
-            isNewUser,
-            hasExpense,
-            termsAgreed,
+            isNewUser: isNewUser ?? '',
+            hasExpense: hasExpense ?? false,
+            termsAgreed: termsAgreed ?? false,
           },
         };
       }

--- a/apps/mobile/shared/types/api.types.ts
+++ b/apps/mobile/shared/types/api.types.ts
@@ -19,16 +19,7 @@ export interface AuthTokens {
  * 로그인 응답 데이터 타입
  */
 export interface LoginData extends AuthTokens {
-  isNewUser: string;
+  isNewUser: boolean;
   hasExpense: boolean;
   termsAgreed: boolean;
-}
-
-/**
- * 소셜 로그인 응답 타입 (bridge에서 사용)
- */
-export interface SocialLoginData extends AuthTokens {
-  isNewUser?: string;
-  hasExpense?: boolean;
-  termsAgreed?: boolean;
 }

--- a/apps/web/src/entities/category/model/store.ts
+++ b/apps/web/src/entities/category/model/store.ts
@@ -14,8 +14,16 @@ export const useCategoryStore = create<CategoryPinnedStore>()(
   persist(
     (set, get) => ({
       pinnedCategoryIds: null,
-      setPinnedCategoryIds: (ids) =>
-        set({ pinnedCategoryIds: ids.slice(0, PINNED_CATEGORY_LIMIT) }),
+      setPinnedCategoryIds: (ids) => {
+        const current = get().pinnedCategoryIds;
+        if (current === null) {
+          set({ pinnedCategoryIds: ids.slice(0, PINNED_CATEGORY_LIMIT) });
+          return;
+        }
+        // 기존 순서 유지, 새 ID만 뒤에 추가 (기존 ID 제거하지 않음)
+        const newIds = ids.filter((id) => !current.includes(id));
+        set({ pinnedCategoryIds: [...current, ...newIds].slice(0, PINNED_CATEGORY_LIMIT) });
+      },
       selectCategory: (id) => {
         const { pinnedCategoryIds } = get();
         const current = pinnedCategoryIds ?? [];

--- a/apps/web/src/features/auth/model/useAppleLogin.ts
+++ b/apps/web/src/features/auth/model/useAppleLogin.ts
@@ -6,7 +6,7 @@ import { getPlatform } from '@/shared/utils';
 interface AppleLoginData {
   accessToken: string;
   refreshToken: string;
-  isNewUser?: string;
+  isNewUser?: boolean;
   hasExpense?: boolean;
   termsAgreed?: boolean;
 }

--- a/apps/web/src/features/auth/model/useKakaoLogin.ts
+++ b/apps/web/src/features/auth/model/useKakaoLogin.ts
@@ -3,9 +3,17 @@ import type { AppBridge } from '@repo/bridge';
 import { useBridge, initializeBridge } from '@/shared/lib/bridge';
 import { getPlatform } from '@/shared/utils';
 
+interface KakaoLoginData {
+  accessToken: string;
+  refreshToken: string;
+  isNewUser?: boolean;
+  hasExpense?: boolean;
+  termsAgreed?: boolean;
+}
+
 interface KakaoLoginOptions {
   redirectUri?: string;
-  onSuccess?: () => void;
+  onSuccess?: (data?: KakaoLoginData) => void;
   onError?: (error: Error) => void;
 }
 
@@ -37,7 +45,7 @@ export const useKakaoLogin = (options: KakaoLoginOptions = {}): KakaoLoginReturn
         if (currentBridge) {
           const result = await currentBridge.socialLogin('kakao');
           if (result.success) {
-            onSuccess?.();
+            onSuccess?.(result.data);
           } else {
             onError?.(new Error(result.message || '카카오 로그인에 실패했습니다.'));
           }

--- a/apps/web/src/features/auth/ui/socialLogin/SocialLoginButtons.tsx
+++ b/apps/web/src/features/auth/ui/socialLogin/SocialLoginButtons.tsx
@@ -38,11 +38,15 @@ export const SocialLoginButtons = () => {
   };
 
   const { handleKakaoLogin } = useKakaoLogin({
-    onSuccess: async () => {
+    onSuccess: async (data) => {
       await syncNativeToken();
       setIsNativeLoginLoading(false);
       toast.success('로그인에 성공했어요');
-      router.replace('/');
+      if (data?.termsAgreed) {
+        router.replace(ROUTES.HOME);
+      } else {
+        router.replace(ROUTES.AGREEMENT);
+      }
     },
     onError: () => {
       setIsNativeLoginLoading(false);

--- a/apps/web/src/features/expense/hooks/index.ts
+++ b/apps/web/src/features/expense/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useAddCategoryForm, ICON_OPTIONS, VALID_NAME_REGEX } from './useAddCategoryForm';
+export type { UseAddCategoryFormOptions, ValidationError } from './useAddCategoryForm';

--- a/apps/web/src/features/expense/hooks/useAddCategoryForm.ts
+++ b/apps/web/src/features/expense/hooks/useAddCategoryForm.ts
@@ -1,0 +1,115 @@
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { categoryQueries } from '../model/categoryQueries';
+import type { Category } from '../index';
+
+export const VALID_NAME_REGEX = /^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$/;
+
+export const ICON_OPTIONS: Category[] = [
+  { id: 'shopping', icon: 'shopping', label: '쇼핑' },
+  { id: 'cook', icon: 'cook', label: '요리' },
+  { id: 'coffee', icon: 'coffee', label: '커피' },
+  { id: 'credit', icon: 'credit', label: '카드' },
+  { id: 'book', icon: 'book', label: '도서' },
+  { id: 'beauty', icon: 'beauty', label: '뷰티' },
+  { id: 'beer', icon: 'beer', label: '맥주' },
+  { id: 'camera', icon: 'camera', label: '카메라' },
+  { id: 'cup', icon: 'cup', label: '컵' },
+];
+
+export interface UseAddCategoryFormOptions {
+  /** 수정 모드일 때 제외할 카테고리 ID */
+  excludeId?: number | null;
+  /** 초기 카테고리 이름 */
+  initialName?: string;
+  /** 초기 아이콘 */
+  initialIcon?: string;
+}
+
+export type ValidationError = 'invalid' | 'duplicate' | null;
+
+export const useAddCategoryForm = (options: UseAddCategoryFormOptions = {}) => {
+  const { excludeId = null, initialName = '', initialIcon } = options;
+
+  const { data: categoryData } = useQuery(categoryQueries.listQuery());
+  const categories = useMemo(() => categoryData?.result ?? [], [categoryData?.result]);
+
+  const [categoryName, setCategoryName] = useState(initialName);
+  const [selectedIcon, setSelectedIcon] = useState<Category | null>(() => {
+    if (initialIcon) {
+      return ICON_OPTIONS.find((opt) => opt.icon === initialIcon) ?? null;
+    }
+    return null;
+  });
+  const [tempIcon, setTempIcon] = useState<Category | null>(null);
+
+  // 에러 검사
+  const validationError = useMemo<ValidationError>(() => {
+    if (!categoryName) return null;
+
+    // 한글, 영문, 숫자만 허용
+    if (!VALID_NAME_REGEX.test(categoryName)) {
+      return 'invalid';
+    }
+
+    // 이미 존재하는 이름인지 확인 (excludeId가 있으면 해당 ID는 제외)
+    const isDuplicate = categories.some(
+      (c) => c.name?.toLowerCase() === categoryName.toLowerCase() && c.id !== excludeId
+    );
+
+    if (isDuplicate) {
+      return 'duplicate';
+    }
+
+    return null;
+  }, [categoryName, categories, excludeId]);
+
+  // 에러 메시지
+  const errorMessage =
+    validationError === 'duplicate'
+      ? '이미 존재하는 이름이에요.'
+      : '한글, 영문, 숫자만 5자 이내로 입력가능해요.';
+
+  const hasError = validationError !== null;
+
+  // 수정 모드에서 변경 사항이 있는지 확인
+  const hasChanges =
+    excludeId !== null ? categoryName !== initialName || selectedIcon?.icon !== initialIcon : true;
+
+  const isValid = categoryName && selectedIcon && !hasError && hasChanges;
+
+  // Icon Picker 핸들러
+  const handleOpenIconPicker = (onOpen: () => void) => {
+    setTempIcon(selectedIcon);
+    onOpen();
+  };
+
+  const handleConfirmIcon = (onClose: () => void) => {
+    setSelectedIcon(tempIcon);
+    onClose();
+  };
+
+  return {
+    // State
+    categoryName,
+    setCategoryName,
+    selectedIcon,
+    setSelectedIcon,
+    tempIcon,
+    setTempIcon,
+
+    // Validation
+    validationError,
+    errorMessage,
+    hasError,
+    isValid,
+    hasChanges,
+
+    // Handlers
+    handleOpenIconPicker,
+    handleConfirmIcon,
+
+    // Data
+    categories,
+  };
+};

--- a/apps/web/src/features/expense/index.ts
+++ b/apps/web/src/features/expense/index.ts
@@ -15,3 +15,6 @@ export type {
   IconPickerBottomSheetTemplateProps,
   ExpenseEditBottomSheetProps,
 } from './ui';
+
+export { useAddCategoryForm, ICON_OPTIONS, VALID_NAME_REGEX } from './hooks';
+export type { UseAddCategoryFormOptions, ValidationError } from './hooks';

--- a/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.css.ts
+++ b/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.css.ts
@@ -1,0 +1,14 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  padding: '2.9rem 1.8rem 0 1.8rem',
+  alignItems: 'start',
+  gap: '3rem',
+});
+
+export const inputFieldStyle = style({
+  gap: '1rem',
+});

--- a/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.tsx
+++ b/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.tsx
@@ -14,30 +14,19 @@ import {
   AlertDialog,
 } from '@/shared/ui';
 import { IcLeftChevron } from 'public/icons';
-import React, { useState, useMemo } from 'react';
+import React from 'react';
 import * as styles from './AddCategoryStep.css';
-import { IconPickerBottomSheetTemplate } from '@/features/expense';
-import type { Category } from '@/features/expense';
+import {
+  IconPickerBottomSheetTemplate,
+  useAddCategoryForm,
+  ICON_OPTIONS,
+} from '@/features/expense';
 import { useModal } from '@/shared/hooks';
 import { useCategoryStore } from '@/entities/category/model/store';
 import { useExpenseFormStore } from '@/widgets/expenseRecordFunnel/model/store';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { categoryQueries } from '@/features/expense/model/categoryQueries';
 import { CategoryDetailsDTO } from '@/features/expense/model/types';
-
-const VALID_NAME_REGEX = /^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$/;
-
-const ICON_OPTIONS: Category[] = [
-  { id: 'shopping', icon: 'shopping', label: '쇼핑' },
-  { id: 'cook', icon: 'cook', label: '요리' },
-  { id: 'coffee', icon: 'coffee', label: '커피' },
-  { id: 'credit', icon: 'credit', label: '카드' },
-  { id: 'book', icon: 'book', label: '도서' },
-  { id: 'beauty', icon: 'beauty', label: '뷰티' },
-  { id: 'beer', icon: 'beer', label: '맥주' },
-  { id: 'camera', icon: 'camera', label: '카메라' },
-  { id: 'cup', icon: 'cup', label: '컵' },
-];
 
 export interface AddCategoryStepProps {
   onBack: () => void;
@@ -55,8 +44,19 @@ export const AddCategoryStep = ({ onBack }: AddCategoryStepProps) => {
   const queryClient = useQueryClient();
   const { selectCategory } = useCategoryStore();
   const { setCategoryId } = useExpenseFormStore();
-  const { data: categoryData } = useQuery(categoryQueries.listQuery());
-  const categories = useMemo(() => categoryData?.result ?? [], [categoryData?.result]);
+
+  const {
+    categoryName,
+    setCategoryName,
+    selectedIcon,
+    tempIcon,
+    setTempIcon,
+    errorMessage,
+    hasError,
+    isValid,
+    handleOpenIconPicker,
+    handleConfirmIcon,
+  } = useAddCategoryForm();
 
   const { mutate: createCategory, isPending } = useMutation({
     ...categoryQueries.createMutation(queryClient),
@@ -72,43 +72,6 @@ export const AddCategoryStep = ({ onBack }: AddCategoryStepProps) => {
       onBack();
     },
   });
-
-  const [categoryName, setCategoryName] = useState('');
-  const [selectedIcon, setSelectedIcon] = useState<Category | null>(null);
-  const [tempIcon, setTempIcon] = useState<Category | null>(null);
-
-  // 에러 검사
-  const validationError = useMemo(() => {
-    if (!categoryName) return null;
-    if (!VALID_NAME_REGEX.test(categoryName)) {
-      return 'invalid';
-    }
-    const isDuplicate = categories.some(
-      (c) => c.name?.toLowerCase() === categoryName.toLowerCase()
-    );
-    if (isDuplicate) {
-      return 'duplicate';
-    }
-    return null;
-  }, [categoryName, categories]);
-
-  const errorMessage =
-    validationError === 'duplicate'
-      ? '이미 존재하는 이름이에요.'
-      : '한글, 영문, 숫자만 5자 이내로 입력가능해요.';
-
-  const hasError = validationError !== null;
-  const isValid = categoryName && selectedIcon && !hasError;
-
-  const handleOpenIconPicker = () => {
-    setTempIcon(selectedIcon);
-    openBottomSheet();
-  };
-
-  const handleConfirm = () => {
-    setSelectedIcon(tempIcon);
-    closeBottomSheet();
-  };
 
   const handleSubmit = () => {
     if (!selectedIcon) return;
@@ -155,7 +118,7 @@ export const AddCategoryStep = ({ onBack }: AddCategoryStepProps) => {
             icon={selectedIcon?.icon ?? 'plus'}
             size='lg'
             type='neutral'
-            onClick={handleOpenIconPicker}
+            onClick={() => handleOpenIconPicker(openBottomSheet)}
           />
         </InputField>
       </div>
@@ -164,7 +127,7 @@ export const AddCategoryStep = ({ onBack }: AddCategoryStepProps) => {
           categories={ICON_OPTIONS}
           selectedId={tempIcon?.id}
           onSelect={setTempIcon}
-          onConfirm={handleConfirm}
+          onConfirm={() => handleConfirmIcon(closeBottomSheet)}
           onClose={closeBottomSheet}
         />
       </BottomSheet>

--- a/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.tsx
+++ b/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import {
+  TopBar,
+  vars,
+  Text,
+  InputField,
+  TextInput,
+  CategoryBtn,
+  BottomFixedArea,
+  Button,
+  BottomSheet,
+  useToast,
+  AlertDialog,
+} from '@/shared/ui';
+import { IcLeftChevron } from 'public/icons';
+import React, { useState, useMemo } from 'react';
+import * as styles from './AddCategoryStep.css';
+import { IconPickerBottomSheetTemplate } from '@/features/expense';
+import type { Category } from '@/features/expense';
+import { useModal } from '@/shared/hooks';
+import { useCategoryStore } from '@/entities/category/model/store';
+import { useExpenseFormStore } from '@/widgets/expenseRecordFunnel/model/store';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { categoryQueries } from '@/features/expense/model/categoryQueries';
+import { CategoryDetailsDTO } from '@/features/expense/model/types';
+
+const VALID_NAME_REGEX = /^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$/;
+
+const ICON_OPTIONS: Category[] = [
+  { id: 'shopping', icon: 'shopping', label: '쇼핑' },
+  { id: 'cook', icon: 'cook', label: '요리' },
+  { id: 'coffee', icon: 'coffee', label: '커피' },
+  { id: 'credit', icon: 'credit', label: '카드' },
+  { id: 'book', icon: 'book', label: '도서' },
+  { id: 'beauty', icon: 'beauty', label: '뷰티' },
+  { id: 'beer', icon: 'beer', label: '맥주' },
+  { id: 'camera', icon: 'camera', label: '카메라' },
+  { id: 'cup', icon: 'cup', label: '컵' },
+];
+
+export interface AddCategoryStepProps {
+  onBack: () => void;
+}
+
+export const AddCategoryStep = ({ onBack }: AddCategoryStepProps) => {
+  const {
+    isOpen: isBottomSheetOpen,
+    openModal: openBottomSheet,
+    closeModal: closeBottomSheet,
+  } = useModal();
+  const { isOpen: isAlertOpen, openModal: openAlert, closeModal: closeAlert } = useModal();
+  const toast = useToast();
+
+  const queryClient = useQueryClient();
+  const { selectCategory } = useCategoryStore();
+  const { setCategoryId } = useExpenseFormStore();
+  const { data: categoryData } = useQuery(categoryQueries.listQuery());
+  const categories = useMemo(() => categoryData?.result ?? [], [categoryData?.result]);
+
+  const { mutate: createCategory, isPending } = useMutation({
+    ...categoryQueries.createMutation(queryClient),
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({ queryKey: categoryQueries.all });
+      const newId = response.result?.id;
+      if (newId) {
+        selectCategory(newId);
+        setCategoryId(newId);
+      }
+      toast.success('카테고리가 추가되었어요!');
+      useExpenseFormStore.setState({ shouldOpenCategorySheet: true });
+      onBack();
+    },
+  });
+
+  const [categoryName, setCategoryName] = useState('');
+  const [selectedIcon, setSelectedIcon] = useState<Category | null>(null);
+  const [tempIcon, setTempIcon] = useState<Category | null>(null);
+
+  // 에러 검사
+  const validationError = useMemo(() => {
+    if (!categoryName) return null;
+    if (!VALID_NAME_REGEX.test(categoryName)) {
+      return 'invalid';
+    }
+    const isDuplicate = categories.some(
+      (c) => c.name?.toLowerCase() === categoryName.toLowerCase()
+    );
+    if (isDuplicate) {
+      return 'duplicate';
+    }
+    return null;
+  }, [categoryName, categories]);
+
+  const errorMessage =
+    validationError === 'duplicate'
+      ? '이미 존재하는 이름이에요.'
+      : '한글, 영문, 숫자만 5자 이내로 입력가능해요.';
+
+  const hasError = validationError !== null;
+  const isValid = categoryName && selectedIcon && !hasError;
+
+  const handleOpenIconPicker = () => {
+    setTempIcon(selectedIcon);
+    openBottomSheet();
+  };
+
+  const handleConfirm = () => {
+    setSelectedIcon(tempIcon);
+    closeBottomSheet();
+  };
+
+  const handleSubmit = () => {
+    if (!selectedIcon) return;
+    createCategory({
+      name: categoryName,
+      icon: selectedIcon.icon as CategoryDetailsDTO['icon'],
+    });
+  };
+
+  const handleBack = () => {
+    const hasInput = categoryName || selectedIcon;
+    if (!hasInput) {
+      onBack();
+    } else {
+      openAlert();
+    }
+  };
+
+  return (
+    <div>
+      <TopBar
+        left={<IcLeftChevron onClick={handleBack} />}
+        center={
+          <Text variant='t1' color={vars.color.text.primary}>
+            {'카테고리 추가'}
+          </Text>
+        }
+      />
+      <div className={styles.container}>
+        <Text variant='t4' color={vars.color.text.primary}>
+          카테고리 이름을 <br />
+          알려주세요
+        </Text>
+        <TextInput
+          placeholder='이름을 입력해주세요'
+          value={categoryName}
+          onValueChange={setCategoryName}
+          error={hasError}
+          errorMessage={errorMessage}
+          maxLength={5}
+        />
+        <InputField label='아이콘' className={styles.inputFieldStyle}>
+          <CategoryBtn
+            icon={selectedIcon?.icon ?? 'plus'}
+            size='lg'
+            type='neutral'
+            onClick={handleOpenIconPicker}
+          />
+        </InputField>
+      </div>
+      <BottomSheet isOpen={isBottomSheetOpen} onClose={closeBottomSheet}>
+        <IconPickerBottomSheetTemplate
+          categories={ICON_OPTIONS}
+          selectedId={tempIcon?.id}
+          onSelect={setTempIcon}
+          onConfirm={handleConfirm}
+          onClose={closeBottomSheet}
+        />
+      </BottomSheet>
+      <BottomFixedArea zIndex={1}>
+        <Button variant='primary' disabled={!isValid || isPending} size='lg' onClick={handleSubmit}>
+          추가하기
+        </Button>
+      </BottomFixedArea>
+      <AlertDialog
+        isOpen={isAlertOpen}
+        onClose={closeAlert}
+        variant='left'
+        title='카테고리 추가를 그만둘까요?'
+        description='지금 나가면 카테고리는 추가되지 않아요.'
+        cancelText='그만두기'
+        confirmText='계속 추가하기'
+        onCancel={onBack}
+      />
+    </div>
+  );
+};

--- a/apps/web/src/features/expense/ui/steps/AddCategoryStep/index.ts
+++ b/apps/web/src/features/expense/ui/steps/AddCategoryStep/index.ts
@@ -1,0 +1,1 @@
+export { AddCategoryStep } from './AddCategoryStep';

--- a/apps/web/src/features/expense/ui/steps/UsageCategoryStep/UsageCategoryStep.tsx
+++ b/apps/web/src/features/expense/ui/steps/UsageCategoryStep/UsageCategoryStep.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useMemo, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import {
   Button,
   InputField,
@@ -17,24 +16,23 @@ import { useExpenseFormStore } from '@/widgets/expenseRecordFunnel/model/store';
 import { useCategoryStore } from '@/entities/category/model/store';
 import { useQuery } from '@tanstack/react-query';
 import { categoryQueries } from '@/features/expense/model/categoryQueries';
-import { ROUTES } from '@/shared/constants';
-
 const MAX_LENGTH = 20;
 const VALID_NAME_REGEX = /^[가-힣a-zA-Z0-9\s]*$/;
 
 export interface UsageCategoryStepProps {
   onNext: (usageHistory: string, categoryId: number) => void;
+  onAddCategory: () => void;
   defaultUsageHistory?: string;
   defaultCategoryId?: number;
 }
 
 export const UsageCategoryStep = ({
   onNext,
+  onAddCategory,
   defaultUsageHistory,
   defaultCategoryId,
 }: UsageCategoryStepProps) => {
   const { isOpen, openModal, closeModal } = useModal();
-  const router = useRouter();
   const { pinnedCategoryIds, selectCategory, setPinnedCategoryIds } = useCategoryStore();
   const { data: categoryResponse } = useQuery(categoryQueries.listQuery());
   const categories = useMemo(() => categoryResponse?.result ?? [], [categoryResponse?.result]);
@@ -42,10 +40,7 @@ export const UsageCategoryStep = ({
   useEffect(() => {
     if (categories.length === 0) return;
 
-    const ids = categories
-      .filter((c) => c.id != null)
-      .slice(0, 7)
-      .map((c) => c.id);
+    const ids = categories.filter((c) => c.id != null).map((c) => c.id);
     setPinnedCategoryIds(ids);
   }, [categories, setPinnedCategoryIds]);
 
@@ -81,8 +76,26 @@ export const UsageCategoryStep = ({
   useEffect(() => {
     if (selectedCategory || defaultCategoryId == null) return;
     const found = categoryOptions.find((c) => c.id === String(defaultCategoryId));
-    if (found) setSelectedCategory(found);
-  }, [categoryOptions, defaultCategoryId, selectedCategory]);
+    if (found) {
+      setSelectedCategory(found);
+      if (isOpen) setTempCategory(found);
+    }
+  }, [categoryOptions, defaultCategoryId, selectedCategory, isOpen]);
+
+  useEffect(() => {
+    const { shouldOpenCategorySheet, categoryId } = useExpenseFormStore.getState();
+    if (shouldOpenCategorySheet) {
+      openModal();
+      useExpenseFormStore.setState({ shouldOpenCategorySheet: false });
+      if (categoryId) {
+        const found = categoryOptions.find((c) => c.id === String(categoryId));
+        if (found) {
+          setSelectedCategory(found);
+          setTempCategory(found);
+        }
+      }
+    }
+  }, [openModal, categoryOptions]);
 
   // 바텀시트용: 선택된 카테고리가 맨 앞에 오도록 정렬
   const sheetCategories = useMemo(() => {
@@ -114,8 +127,9 @@ export const UsageCategoryStep = ({
     useExpenseFormStore.setState({
       usageHistory,
       ...(selectedCategory && { categoryId: +selectedCategory.id }),
+      shouldOpenCategorySheet: true,
     });
-    router.push(ROUTES.EXPENSE_CATEGORY);
+    onAddCategory();
   };
 
   return (

--- a/apps/web/src/features/expense/ui/steps/index.ts
+++ b/apps/web/src/features/expense/ui/steps/index.ts
@@ -1,3 +1,4 @@
 export { AmountDateStep } from './AmountDateStep';
 export { UsageCategoryStep } from './UsageCategoryStep';
 export { SatisfactionStep } from './SatisfactionStep';
+export { AddCategoryStep } from './AddCategoryStep';

--- a/apps/web/src/shared/lib/navigation/useAppNavigation.ts
+++ b/apps/web/src/shared/lib/navigation/useAppNavigation.ts
@@ -2,6 +2,7 @@
 
 import { useRouter, usePathname } from 'next/navigation';
 import { NavToggleOption } from '@/shared/ui/navToggle';
+import { useExpenseFormStore } from '@/widgets/expenseRecordFunnel/model/store';
 
 export const useAppNavigation = () => {
   const router = useRouter();
@@ -16,6 +17,7 @@ export const useAppNavigation = () => {
   };
 
   const handleAddExpense = () => {
+    useExpenseFormStore.getState().reset();
     router.push('/expense');
   };
 

--- a/apps/web/src/shared/styles/global.css.ts
+++ b/apps/web/src/shared/styles/global.css.ts
@@ -6,12 +6,15 @@ globalStyle('*', {
   padding: 0,
   margin: 0,
   fontFamily: 'var(--font-suit), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  WebkitTouchCallout: 'none',
+  userSelect: 'none',
 });
 
 globalStyle('html', {
   fontSize: '62.5%',
   maxWidth: '100vw',
   overflowX: 'hidden',
+  overscrollBehavior: 'none',
 });
 
 globalStyle('a', {
@@ -26,6 +29,7 @@ globalStyle('body', {
   minHeight: '100dvh',
   margin: '0 auto',
   background: '#F6F7F9',
+  overscrollBehavior: 'none',
   '@media': {
     '(min-width: 431px)': {
       boxShadow: '0 0 16px rgba(0,0,0,0.2)',

--- a/apps/web/src/shared/ui/button/Button.tsx
+++ b/apps/web/src/shared/ui/button/Button.tsx
@@ -18,9 +18,14 @@ export const Button = ({
   type = 'button',
   ...props
 }: PropsWithChildren<ButtonProps>): React.JSX.Element => {
+  const handleMouseDown = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+  };
+
   return (
     <button
       className={button({ variant, size, disabled })}
+      onMouseDown={handleMouseDown}
       onClick={onClick}
       disabled={disabled}
       type={type}

--- a/apps/web/src/widgets/addCategory/ui/AddCategory.tsx
+++ b/apps/web/src/widgets/addCategory/ui/AddCategory.tsx
@@ -13,31 +13,20 @@ import {
   AlertDialog,
 } from '@/shared/ui';
 import { IcLeftChevron } from 'public/icons';
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import * as styles from './AddCategory.css';
-import { IconPickerBottomSheetTemplate } from '@/features/expense';
-import type { Category } from '@/features/expense';
+import {
+  IconPickerBottomSheetTemplate,
+  useAddCategoryForm,
+  ICON_OPTIONS,
+} from '@/features/expense';
 import { useModal } from '@/shared/hooks';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCategoryStore } from '@/entities/category/model/store';
 import { useExpenseFormStore } from '@/widgets/expenseRecordFunnel/model/store';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { categoryQueries } from '@/features/expense/model/categoryQueries';
 import { CategoryDetailsDTO } from '@/features/expense/model/types';
-
-const VALID_NAME_REGEX = /^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$/;
-
-const ICON_OPTIONS: Category[] = [
-  { id: 'shopping', icon: 'shopping', label: '쇼핑' },
-  { id: 'cook', icon: 'cook', label: '요리' },
-  { id: 'coffee', icon: 'coffee', label: '커피' },
-  { id: 'credit', icon: 'credit', label: '카드' },
-  { id: 'book', icon: 'book', label: '도서' },
-  { id: 'beauty', icon: 'beauty', label: '뷰티' },
-  { id: 'beer', icon: 'beer', label: '맥주' },
-  { id: 'camera', icon: 'camera', label: '카메라' },
-  { id: 'cup', icon: 'cup', label: '컵' },
-];
 
 export const AddCategory = () => {
   const {
@@ -57,8 +46,44 @@ export const AddCategory = () => {
   const queryClient = useQueryClient();
   const { selectCategory } = useCategoryStore();
   const { setCategoryId } = useExpenseFormStore();
-  const { data: categoryData } = useQuery(categoryQueries.listQuery());
-  const categories = useMemo(() => categoryData?.result ?? [], [categoryData?.result]);
+
+  // 수정 모드일 때 기존 카테고리 찾기
+  const editingCategory = isEditMode
+    ? queryClient
+        .getQueryData<{
+          result?: Array<{ id: number; name?: string; icon?: string }>;
+        }>(categoryQueries.listQuery().queryKey)
+        ?.result?.find((c) => c.id === editId)
+    : null;
+
+  const {
+    categoryName,
+    setCategoryName,
+    selectedIcon,
+    setSelectedIcon,
+    tempIcon,
+    setTempIcon,
+    errorMessage,
+    hasError,
+    isValid,
+    handleOpenIconPicker,
+    handleConfirmIcon,
+  } = useAddCategoryForm({
+    excludeId: isEditMode ? editId : null,
+    initialName: editingCategory?.name ?? '',
+    initialIcon: editingCategory?.icon ?? '',
+  });
+
+  // 수정 모드일 때 초기값 설정
+  useEffect(() => {
+    if (editingCategory) {
+      setCategoryName(editingCategory.name ?? '');
+      const iconOption = ICON_OPTIONS.find((opt) => opt.icon === editingCategory.icon);
+      if (iconOption) {
+        setSelectedIcon(iconOption);
+      }
+    }
+  }, [editingCategory, setCategoryName, setSelectedIcon]);
 
   const { mutate: createCategory, isPending } = useMutation({
     ...categoryQueries.createMutation(queryClient),
@@ -73,67 +98,6 @@ export const AddCategory = () => {
       router.back();
     },
   });
-
-  // 수정 모드일 때 기존 카테고리 찾기
-  const editingCategory = isEditMode ? categories.find((c) => c.id === editId) : null;
-
-  const [categoryName, setCategoryName] = useState('');
-  const [selectedIcon, setSelectedIcon] = useState<Category | null>(null);
-  const [tempIcon, setTempIcon] = useState<Category | null>(null);
-
-  // 수정 모드일 때 초기값 설정
-  useEffect(() => {
-    if (editingCategory) {
-      setCategoryName(editingCategory.name ?? '');
-      const iconOption = ICON_OPTIONS.find((opt) => opt.icon === editingCategory.icon);
-      if (iconOption) {
-        setSelectedIcon(iconOption);
-      }
-    }
-  }, [editingCategory]);
-
-  // 에러 검사
-  const validationError = useMemo(() => {
-    if (!categoryName) return null;
-    // 한글, 영문, 숫자만 허용
-    if (!VALID_NAME_REGEX.test(categoryName)) {
-      return 'invalid';
-    }
-    // 이미 존재하는 이름인지 확인 (수정 모드일 때 자기 자신은 제외)
-    const isDuplicate = categories.some(
-      (c) =>
-        c.name?.toLowerCase() === categoryName.toLowerCase() && (!isEditMode || c.id !== editId)
-    );
-    if (isDuplicate) {
-      return 'duplicate';
-    }
-    return null;
-  }, [categoryName, categories, isEditMode, editId]);
-
-  // 에러 메시지 (항상 표시, 에러 시 다른 메시지)
-  const errorMessage =
-    validationError === 'duplicate'
-      ? '이미 존재하는 이름이에요.'
-      : '한글, 영문, 숫자만 5자 이내로 입력가능해요.';
-
-  const hasError = validationError !== null;
-
-  // 수정 모드에서 변경 사항이 있는지 확인
-  const hasChanges = isEditMode
-    ? categoryName !== (editingCategory?.name ?? '') || selectedIcon?.icon !== editingCategory?.icon
-    : true;
-
-  const isValid = categoryName && selectedIcon && !hasError && hasChanges;
-
-  const handleOpenIconPicker = () => {
-    setTempIcon(selectedIcon);
-    openBottomSheet();
-  };
-
-  const handleConfirm = () => {
-    setSelectedIcon(tempIcon);
-    closeBottomSheet();
-  };
 
   const handleSubmit = () => {
     if (!selectedIcon) return;
@@ -177,7 +141,7 @@ export const AddCategory = () => {
             icon={selectedIcon?.icon ?? 'plus'}
             size='lg'
             type='neutral'
-            onClick={handleOpenIconPicker}
+            onClick={() => handleOpenIconPicker(openBottomSheet)}
           />
         </InputField>
       </div>
@@ -186,7 +150,7 @@ export const AddCategory = () => {
           categories={ICON_OPTIONS}
           selectedId={tempIcon?.id}
           onSelect={setTempIcon}
-          onConfirm={handleConfirm}
+          onConfirm={() => handleConfirmIcon(closeBottomSheet)}
           onClose={closeBottomSheet}
         />
       </BottomSheet>

--- a/apps/web/src/widgets/expenseRecordFunnel/model/expenseFunnelContext.ts
+++ b/apps/web/src/widgets/expenseRecordFunnel/model/expenseFunnelContext.ts
@@ -17,6 +17,15 @@ export type UsageCategoryStepType = {
   usageHistory?: string;
   emotionType?: EmotionType;
 };
+// Step 2.5: 카테고리 추가 (사용처카테고리에서 진입)
+export type AddCategoryStepType = {
+  amount: number;
+  expendedAt: string;
+  categoryId?: number;
+  usageHistory?: string;
+  emotionType?: EmotionType;
+};
+
 // Step 3: 사용처 + 카테고리
 export type SatisfactionStepType = {
   amount: number;

--- a/apps/web/src/widgets/expenseRecordFunnel/model/store.ts
+++ b/apps/web/src/widgets/expenseRecordFunnel/model/store.ts
@@ -7,6 +7,7 @@ interface ExpenseFormState {
   usageHistory?: string;
   categoryId?: number;
   emotionType?: string;
+  shouldOpenCategorySheet?: boolean;
 }
 
 interface ExpenseFormActions {
@@ -31,6 +32,7 @@ export const useExpenseFormStore = create<ExpenseFormState & ExpenseFormActions>
           usageHistory: undefined,
           categoryId: undefined,
           emotionType: undefined,
+          shouldOpenCategorySheet: undefined,
         }),
     }),
     {

--- a/apps/web/src/widgets/expenseRecordFunnel/ui/ExpenseRecordFunnel.tsx
+++ b/apps/web/src/widgets/expenseRecordFunnel/ui/ExpenseRecordFunnel.tsx
@@ -7,6 +7,7 @@ import * as styles from './ExpenseRecordFunnel.css';
 import type {
   AmountDateStepType,
   UsageCategoryStepType,
+  AddCategoryStepType,
   SatisfactionStepType,
   SubmitStepType,
 } from '../model/expenseFunnelContext';
@@ -15,7 +16,12 @@ import { StepIndicator, TopBar, Text, vars, AlertDialog, useToast } from '@/shar
 import { useModal } from '@/shared/hooks';
 import { formatDateToISO } from '@/shared/utils';
 import { IcLeftChevron } from 'public/icons';
-import { AmountDateStep, SatisfactionStep, UsageCategoryStep } from '@/features/expense/ui/steps';
+import {
+  AmountDateStep,
+  SatisfactionStep,
+  UsageCategoryStep,
+  AddCategoryStep,
+} from '@/features/expense/ui/steps';
 import { expenseQueries } from '@/features/expense/model/expenseQueries';
 import type { EmotionType } from '@/features/expense/model/types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -26,6 +32,7 @@ import { ROUTES } from '@/shared/constants';
 const STEP_NUMBER = {
   금액날짜입력: 1,
   사용처카테고리: 2,
+  카테고리추가: 2,
   만족도입력: 3,
   제출: 3,
 } as const;
@@ -39,6 +46,7 @@ export const ExpenseRecordFunnel = () => {
   const funnel = useFunnel<{
     금액날짜입력: AmountDateStepType;
     사용처카테고리: UsageCategoryStepType;
+    카테고리추가: AddCategoryStepType;
     만족도입력: SatisfactionStepType;
     제출: SubmitStepType;
   }>({
@@ -107,22 +115,24 @@ export const ExpenseRecordFunnel = () => {
 
   return (
     <div className={styles.container}>
-      <div className={styles.header}>
-        <TopBar
-          left={<IcLeftChevron onClick={handleBack} />}
-          center={
-            <Text variant='t1' color={vars.color.text.primary}>
-              소비 기록
-            </Text>
-          }
-          right={
-            <Text variant='h4' color={vars.color.text.secondary} onClick={openModal}>
-              나가기
-            </Text>
-          }
-        />
-        <StepIndicator currentStep={STEP_NUMBER[funnel.step]} totalSteps={3} />
-      </div>
+      {funnel.step !== '카테고리추가' && (
+        <div className={styles.header}>
+          <TopBar
+            left={<IcLeftChevron onClick={handleBack} />}
+            center={
+              <Text variant='t1' color={vars.color.text.primary}>
+                소비 기록
+              </Text>
+            }
+            right={
+              <Text variant='h4' color={vars.color.text.secondary} onClick={openModal}>
+                나가기
+              </Text>
+            }
+          />
+          <StepIndicator currentStep={STEP_NUMBER[funnel.step]} totalSteps={3} />
+        </div>
+      )}
       <funnel.Render
         금액날짜입력={({ history }) => (
           <AmountDateStep
@@ -136,8 +146,10 @@ export const ExpenseRecordFunnel = () => {
             defaultUsageHistory={formStore.usageHistory}
             defaultCategoryId={formStore.categoryId}
             onNext={handleUsageCategoryNext(history)}
+            onAddCategory={() => history.push('카테고리추가', {})}
           />
         )}
+        카테고리추가={() => <AddCategoryStep onBack={() => window.history.back()} />}
         만족도입력={() => (
           <SatisfactionStep
             defaultEmotionType={formStore.emotionType}

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -22,6 +22,9 @@ export interface SocialLoginResult {
   data?: {
     accessToken: string;
     refreshToken: string;
+    isNewUser: boolean;
+    hasExpense: boolean;
+    termsAgreed: boolean;
   };
 }
 


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

<!-- ex) close #1 -->
- close #135

## ✅ 작업 목록

#### 1. 소비기록 진입 시 Store 초기화
- 유저가 소비기록 작성 중 앱을 이탈했다가 재진입하는 경우, 이전 Store 상태가 유지되어 작성 중이던 기록이 남아있는 오류가 있었습니다.
- 소비기록 Step에 진입하는 즉시 Store를 초기화하도록 변경하여 이 문제를 해결했습니다.

#### 2. 카테고리 추가 로직 개선 (AddCategoryStep Funnel 도입)
- **Funnel Step 분리**: 기존에 별도 페이지(`expense/category`)로 이동하던 카테고리 추가 로직을 소비기록 Funnel 내의 `AddCategoryStep`으로 통합했습니다.
  - 별도 페이지 이동 시 Funnel의 히스토리 관리가 어려워, 뒤로가기 시 Step이 꼬이는(처음으로 돌아가거나 엉뚱한 곳으로 가는) 문제가 있어 이를 해결하기 위함입니다.
- 기존 UI와 동일하게 유지하면서, 카테고리 관리와 소비기록 흐름이 자연스럽게 이어지도록 했습니다.

#### 3. 카테고리 추가 후 자동 선택 및 상태 유지
- 새로 카테고리를 추가한 경우, 추가된 카테고리가 자동으로 선택되도록 수정했습니다.
- 카테고리 추가 후 돌아왔을 때 바텀시트가 열린 상태를 유지하여 연속적인 작업이 가능하도록 개선했습니다.

#### 4. 코드 리팩토링
- `useAddCategoryForm` 훅 분리: 카테고리 추가/수정 관련 로직을 별도 훅으로 분리하였습니다.

#### 스타일 추가 및 기타 등
- 스크롤, 드래그 방지 스타일 추가
- 버튼 두번 클릭 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 출시 노트

* **새로운 기능**
  * 지출 기록 흐름에 '카테고리 추가' 단계를 추가하여 바로 새 카테고리 생성 가능
  * 카테고리 추가 화면에 아이콘 선택기 및 입력 검증 제공

* **개선 사항**
  * 카테고리 고정 기능 개선 — 기존 순서 유지, 중복 제거
  * 소셜 로그인 흐름 강화 — 신규/온보딩/약관 동의 상태에 따른 이동 반영
  * 전역 스크롤·터치 및 버튼 눌림 동작 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->