### PR TITLE
Fix: 카테고리 추가후 바텀시트 내려오게 수정

### DIFF
--- a/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.tsx
+++ b/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.tsx
@@ -68,7 +68,7 @@ export const AddCategoryStep = ({ onBack }: AddCategoryStepProps) => {
         setCategoryId(newId);
       }
       toast.success('카테고리가 추가되었어요!');
-      useExpenseFormStore.setState({ shouldOpenCategorySheet: true });
+      useExpenseFormStore.setState({ shouldOpenCategorySheet: false });
       onBack();
     },
   });


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

- close #145

## ✅ 작업 목록

- shouldOpenCategorySheet: false 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 지출 카테고리 생성 후 사용자 인터페이스 흐름이 개선되었습니다. 카테고리 추가 프로세스 완료 시 관련 시트가 자동으로 닫히고 이전 화면으로 자연스럽게 돌아가도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->