### PR TITLE
Fix: 핀 카테고리 동기화 문제 해결 및 선택 정렬 로직 개선

### DIFF
--- a/apps/web/src/entities/category/model/store.ts
+++ b/apps/web/src/entities/category/model/store.ts
@@ -20,9 +20,9 @@ export const useCategoryStore = create<CategoryPinnedStore>()(
           set({ pinnedCategoryIds: ids.slice(0, PINNED_CATEGORY_LIMIT) });
           return;
         }
-        // 기존 순서 유지, 새 ID만 뒤에 추가 (기존 ID 제거하지 않음)
-        const newIds = ids.filter((id) => !current.includes(id));
-        set({ pinnedCategoryIds: [...current, ...newIds].slice(0, PINNED_CATEGORY_LIMIT) });
+        const validCurrent = current.filter((id) => ids.includes(id));
+        const newIds = ids.filter((id) => !validCurrent.includes(id));
+        set({ pinnedCategoryIds: [...validCurrent, ...newIds].slice(0, PINNED_CATEGORY_LIMIT) });
       },
       selectCategory: (id) => {
         const { pinnedCategoryIds } = get();

--- a/apps/web/src/features/expense/ui/steps/UsageCategoryStep/UsageCategoryStep.tsx
+++ b/apps/web/src/features/expense/ui/steps/UsageCategoryStep/UsageCategoryStep.tsx
@@ -33,16 +33,9 @@ export const UsageCategoryStep = ({
   defaultCategoryId,
 }: UsageCategoryStepProps) => {
   const { isOpen, openModal, closeModal } = useModal();
-  const { pinnedCategoryIds, selectCategory, setPinnedCategoryIds } = useCategoryStore();
+  const { selectCategory } = useCategoryStore();
   const { data: categoryResponse } = useQuery(categoryQueries.listQuery());
   const categories = useMemo(() => categoryResponse?.result ?? [], [categoryResponse?.result]);
-
-  useEffect(() => {
-    if (categories.length === 0) return;
-
-    const ids = categories.filter((c) => c.id != null).map((c) => c.id);
-    setPinnedCategoryIds(ids);
-  }, [categories, setPinnedCategoryIds]);
 
   // store 데이터를 Category 타입으로 변환
   const categoryOptions = useMemo<Category[]>(
@@ -55,13 +48,6 @@ export const UsageCategoryStep = ({
     [categories]
   );
 
-  // 홈에 고정 노출되는 카테고리
-  const pinnedCategories = useMemo<Category[]>(() => {
-    return (pinnedCategoryIds ?? [])
-      .map((id) => categoryOptions.find((c) => c.id === String(id)))
-      .filter((c): c is Category => c !== undefined);
-  }, [pinnedCategoryIds, categoryOptions]);
-
   const [usageHistory, setUsageHistory] = useState<string>(defaultUsageHistory ?? '');
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(
     defaultCategoryId != null
@@ -69,6 +55,8 @@ export const UsageCategoryStep = ({
       : null
   );
   const [tempCategory, setTempCategory] = useState<Category | null>(null);
+  // 바텀시트에서 확인된 카테고리 (그리드 선택과 구분하기 위한 상태)
+  const [confirmedCategory, setConfirmedCategory] = useState<Category | null>(null);
 
   const hasValidationError = usageHistory !== '' && !VALID_NAME_REGEX.test(usageHistory);
   const isValid = usageHistory.trim() !== '' && !hasValidationError && selectedCategory !== null;
@@ -92,6 +80,7 @@ export const UsageCategoryStep = ({
         if (found) {
           setSelectedCategory(found);
           setTempCategory(found);
+          setConfirmedCategory(found);
         }
       }
     }
@@ -104,6 +93,18 @@ export const UsageCategoryStep = ({
     const rest = categoryOptions.filter((c) => c.id !== selectedCategory.id);
     return selected ? [selected, ...rest] : categoryOptions;
   }, [categoryOptions, selectedCategory]);
+
+  // 홈에 고정 노출되는 카테고리
+  const pinnedCategories = useMemo<Category[]>(() => {
+    const top7 = categoryOptions.slice(0, 7);
+    if (!confirmedCategory) return top7;
+    // confirmedCategory가 이미 top7에 있으면 맨 앞으로
+    if (top7.some((c) => c.id === confirmedCategory.id)) {
+      return [confirmedCategory, ...top7.filter((c) => c.id !== confirmedCategory.id)];
+    }
+    // top7에 없으면 맨 앞에 추가하고 마지막 하나 제거
+    return [confirmedCategory, ...top7.slice(0, 6)];
+  }, [categoryOptions, confirmedCategory]);
 
   const handleNext = () => {
     if (!isValid || !selectedCategory) return;
@@ -118,6 +119,7 @@ export const UsageCategoryStep = ({
   const handleConfirm = () => {
     if (tempCategory) {
       selectCategory(+tempCategory.id);
+      setConfirmedCategory(tempCategory);
     }
     setSelectedCategory(tempCategory);
     closeModal();


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

- close #149 

## ✅ 작업 목록
Zustand가 localStorage에서 비동기로 복원(hydrate)하는 타이밍과, useQuery로 서버 카테고리 데이터를 fetching하는 타이밍이 꼬이면서 pinnedCategories가 빈 배열이 되는 문제

서버 데이터 도착 →  setPinnedCategoryIds호출 → 직후 persist hydrate가 localStorage 값으로 덮어씀
localStorage에 서버에서 삭제된 카테고리 ID가 남아있어 매칭 실패


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 카테고리 고정 기능을 개선했습니다. 사용자가 선택하여 확인한 카테고리가 고정된 목록의 맨 앞에 우선적으로 표시됩니다. 카테고리 고정 로직을 최적화하여 더욱 직관적인 동작을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->