### PR TITLE
Fix: 탈퇴 후 재로그인 시 이전 계정 홈 캐시 잔존 문제 수정

### DIFF
--- a/apps/web/src/features/auth/model/useWithdraw.ts
+++ b/apps/web/src/features/auth/model/useWithdraw.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/shared/ui';
 import { clearAllUserStorage } from '@/shared/utils';
 import { authQueries } from './authQueries';
@@ -9,11 +9,14 @@ import { authQueries } from './authQueries';
 export const useWithdraw = () => {
   const router = useRouter();
   const toast = useToast();
+  const queryClient = useQueryClient();
 
   const { mutate: withdraw, isPending } = useMutation({
     ...authQueries.withdrawMutation(),
     onSuccess: () => {
       clearAllUserStorage();
+      // 이전 사용자 월별/요약 등 모든 쿼리 캐시 제거 (재로그인 시 다른 사용자 데이터 노출 방지)
+      queryClient.clear();
       toast.success('회원탈퇴가 완료되었어요');
       router.replace('/login');
     },


### PR DESCRIPTION
## 📝 PR 유형

* [ ] 🚀 feature 기능 추가
* [x] 🐞 버그 수정
* [ ] 🔨 리팩토링
* [ ] 📋 문서작성
* [ ] 🌍 빌드 설정 및 문제
* [ ] ETC

## 🔔 관련된 이슈 넘버

close #154

## ✅ 작업 목록

* 탈퇴 후 재로그인 시 이전 계정 홈 데이터가 잠깐 노출되는 문제 원인 분석
* 로그아웃(useLogout)과 탈퇴(useWithdraw) 로직 비교
* useWithdraw 훅에 `useQueryClient` 추가
* 탈퇴 성공(onSuccess) 시:

  * `clearAllUserStorage()` 호출
  * `queryClient.clear()` 추가 호출
* 로그아웃과 동일한 캐시 초기화 동작으로 통일


## 🍰 논의사항
* 추후 로그아웃/탈퇴 공통 처리 로직을 하나의 유틸 또는 훅으로 분리해도 좋을 것 같습니다.


## 📷 ETC

### 원인 요약

* **useLogout**

  * `queryClient.clear()` 호출 → React Query 캐시 초기화
* **useWithdraw**

  * `clearAllUserStorage()`만 호출
  * React Query 캐시는 남아 있어 홈의 월별/일별 소비 데이터가 잠깐 이전 계정 기준으로 표시됨

### 수정 결과

* 탈퇴 성공 시에도 `queryClient.clear()` 호출
* 탈퇴 → 재로그인 시 이전 계정 홈 캐시 완전 제거
* 새 계정 기준 데이터만 표시되도록 수정 완료
