### PR TITLE
Fix: 회원탈퇴 브릿지 추가 및 온보딩 상태 초기화 처리

### DIFF
--- a/apps/mobile/shared/lib/bridge.ts
+++ b/apps/mobile/shared/lib/bridge.ts
@@ -31,6 +31,11 @@ export const appBridge = bridge({
         await authStorage.setTokens(accessToken, refreshToken ?? '');
         const { isNewUser, hasExpense, isTermsAgreed } = result.data;
 
+        // 지출이 있을 경우 온보딩 완료 저장
+        if (hasExpense) {
+          await onboardingStorage.completeOnboarding();
+        }
+
         return {
           success: true,
           data: {
@@ -126,6 +131,12 @@ export const appBridge = bridge({
       // 애플 로그인 사용자는 카카오 세션이 없어 실패할 수 있음 → 무시하고 토큰만 삭제
     }
     await authStorage.clearTokens();
+    await onboardingStorage.clearOnboardingStatus();
+  },
+
+  async requestWithdraw(): Promise<void> {
+    await authStorage.clearTokens();
+    await onboardingStorage.clearOnboardingStatus();
   },
 
   /**

--- a/apps/mobile/shared/lib/onboardingStorage.ts
+++ b/apps/mobile/shared/lib/onboardingStorage.ts
@@ -20,4 +20,8 @@ export const onboardingStorage = {
       console.error('온보딩 상태 저장 실패:', error);
     }
   },
+
+  async clearOnboardingStatus(): Promise<void> {
+    await SecureStore.deleteItemAsync(ONBOARDING_KEY);
+  },
 };

--- a/apps/web/src/features/auth/model/useWithdraw.ts
+++ b/apps/web/src/features/auth/model/useWithdraw.ts
@@ -5,15 +5,24 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/shared/ui';
 import { clearAllUserStorage } from '@/shared/utils';
 import { authQueries } from './authQueries';
+import { useBridge } from '@/shared/lib/bridge';
 
 export const useWithdraw = () => {
   const router = useRouter();
   const toast = useToast();
   const queryClient = useQueryClient();
+  const bridge = useBridge();
 
   const { mutate: withdraw, isPending } = useMutation({
     ...authQueries.withdrawMutation(),
-    onSuccess: () => {
+    onSuccess: async () => {
+      if (bridge) {
+        try {
+          await bridge.requestWithdraw();
+        } catch {
+          // 네이티브 회원탈퇴 실패해도 로컬 정리 진행
+        }
+      }
       clearAllUserStorage();
       // 이전 사용자 월별/요약 등 모든 쿼리 캐시 제거 (재로그인 시 다른 사용자 데이터 노출 방지)
       queryClient.clear();

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -36,6 +36,9 @@ export type AppBridge = {
   // 로그아웃
   requestLogout: () => Promise<void>;
 
+  // 회원탈퇴
+  requestWithdraw: () => Promise<void>;
+
   // 외부 링크 열기 (인앱 브라우저)
   openExternalUrl: (url: string) => Promise<void>;
 


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

- close #159 

## ✅ 작업 목록

현재 `hasExpense` 기준으로 온보딩 여부를 띄우고 있습니다. 서버에서 온보딩 여부에 대한 필드가 추가되면, `hasExpense`를 바꾸면 될 것 같습니다. ! 
```
        // 지출이 있을 경우 온보딩 완료 저장
        if (hasExpense) {
          await onboardingStorage.completeOnboarding();
        }
```
- 회원탈퇴 시 네이티브 정리 처리 — requestWithdraw 브릿지 메서드 추가, 탈퇴 시 토큰 + 온보딩 상태 삭제
- 로그아웃 시 온보딩 상태 초기화 — 기존 로그아웃 흐름에 clearOnboardingStatus 추가
- 로그인 시 온보딩 자동 완료 — hasExpense가 있을 경우 온보딩 완료 상태 저장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 계정 탈퇴 기능 추가: 모든 인증 토큰과 온보딩 상태를 완전히 정리합니다.

* **Bug Fixes**
  * 로그아웃 시 온보딩 상태 초기화 로직 개선
  * 로그인 성공 후 온보딩 상태 완료 처리 추가

* **Improvements**
  * 계정 탈퇴 프로세스에서 로컬 데이터 및 전역 상태 정리 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->