### PR TITLE
 Feat: 배너 및 개별 지출기록 바텀시트에 만족도 API 연동

### DIFF
--- a/apps/web/public/icons/emoji/ic-gray-normal.svg
+++ b/apps/web/public/icons/emoji/ic-gray-normal.svg
@@ -1,6 +1,6 @@
-<svg width="100%" height="100%" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="2" y="1.99902" width="28" height="28" rx="14" fill="#D2D4DA"/>
-<line x1="11.642" y1="21.1783" x2="20.7647" y2="21.1783" stroke="#8E929D" stroke-width="1.995" stroke-linecap="round"/>
-<rect x="7.87891" y="10.8096" width="6.17647" height="6.17647" rx="3.08824" fill="#8E929D"/>
-<rect x="17.9453" y="10.8096" width="6.17647" height="6.17647" rx="3.08824" fill="#8E929D"/>
+<svg width="100%" height="100%" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="28" height="28" rx="14" fill="#D2D4DA"/>
+<line x1="9.64398" y1="19.1802" x2="18.7666" y2="19.1802" stroke="#8E929D" stroke-width="1.995" stroke-linecap="round"/>
+<rect x="5.87793" y="8.8125" width="6.17647" height="6.17647" rx="3.08824" fill="#8E929D"/>
+<rect x="15.9453" y="8.8125" width="6.17647" height="6.17647" rx="3.08824" fill="#8E929D"/>
 </svg>

--- a/apps/web/src/entities/expenseReport/api/getDailyAverageSatisfaction.ts
+++ b/apps/web/src/entities/expenseReport/api/getDailyAverageSatisfaction.ts
@@ -1,0 +1,11 @@
+import { authApi, ENDPOINT } from '@/shared/api';
+
+/**
+ * 일별 종합 소비 만족도 조회
+ * @description 당일 모든 지출 회고가 완료된 경우, 전체 만족도 평균을 문구로 반환합니다.
+ */
+export const getDailyAverageSatisfaction = async (date: string) => {
+  return await authApi.get<string>(ENDPOINT.EXPENSE_REPORT.DAILY_SATISFACTION, {
+    searchParams: { date },
+  });
+};

--- a/apps/web/src/entities/expenseReport/api/index.ts
+++ b/apps/web/src/entities/expenseReport/api/index.ts
@@ -1,1 +1,2 @@
 export { getSummaryRecord } from './getSummaryRecord';
+export { getDailyAverageSatisfaction } from './getDailyAverageSatisfaction';

--- a/apps/web/src/features/expense/model/evaluationLabel.ts
+++ b/apps/web/src/features/expense/model/evaluationLabel.ts
@@ -1,0 +1,14 @@
+import type { EvaluationType } from '@/shared/types/evaluation.types';
+
+const EVALUATION_LABEL_MAP: Record<EvaluationType, string> = {
+  VERY_SATISFIED: '정말 만족했어요',
+  SATISFIED: '만족했어요',
+  NORMAL: '그냥 그랬어요',
+  DISAPPOINTED: '조금 아쉬웠어요',
+  VERY_DISAPPOINTED: '정말 별로였어요',
+};
+
+export const getEvaluationLabel = (evaluationType?: EvaluationType): string => {
+  if (!evaluationType) return '정말 만족했어요';
+  return EVALUATION_LABEL_MAP[evaluationType];
+};

--- a/apps/web/src/features/expense/model/evaluationLabel.ts
+++ b/apps/web/src/features/expense/model/evaluationLabel.ts
@@ -8,7 +8,6 @@ const EVALUATION_LABEL_MAP: Record<EvaluationType, string> = {
   VERY_DISAPPOINTED: '정말 별로였어요',
 };
 
-export const getEvaluationLabel = (evaluationType?: EvaluationType): string => {
-  if (!evaluationType) return '정말 만족했어요';
+export const getEvaluationLabel = (evaluationType: EvaluationType): string => {
   return EVALUATION_LABEL_MAP[evaluationType];
 };

--- a/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
@@ -227,6 +227,7 @@ export const ExpenseEditBottomSheet = ({
         onDateClick={() => setIsCalendarOpen(true)}
         onMoreCategoryClick={() => setIsCategorySheetOpen(true)}
         satisfactionLabel={expense?.emotionType ?? '감정 누락'}
+        satisfactionEvaluationType={expense?.evaluationType}
         confirmDisabled={
           amount <= 0 || !usage || usage.trim().length === 0 || !!amountError || isUsageInvalid
         }

--- a/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx
@@ -42,9 +42,9 @@ export interface ExpenseFormBottomSheetProps {
   /** 더보기 버튼 클릭 시 콜백 */
   onMoreCategoryClick?: () => void;
   /** 만족도 라벨 */
-  satisfactionLabel?: string; //TODO: 임시
+  satisfactionLabel?: string;
   /** 만족도 이모지 */
-  satisfactionEmoji?: string; //TODO: 임시
+  satisfactionEmoji?: string;
   /** 만족도 평가 타입 */
   satisfactionEvaluationType?: EvaluationType;
   /** 삭제 버튼 클릭 시 콜백 */
@@ -86,7 +86,9 @@ export const ExpenseFormBottomSheet = ({
   isUsageError,
 }: ExpenseFormBottomSheetProps) => {
   const formattedAmount = amount !== undefined ? formatNumberWithComma(String(amount)) : '';
-  const evaluationLabel = getEvaluationLabel(satisfactionEvaluationType);
+  const evaluationLabel = satisfactionEvaluationType
+    ? getEvaluationLabel(satisfactionEvaluationType)
+    : null;
 
   return (
     <BaseBottomSheetTemplate>
@@ -130,14 +132,15 @@ export const ExpenseFormBottomSheet = ({
         onMoreClick={onMoreCategoryClick}
       />
 
-      {/* 훌린듯이 소비 */}
       <div className={styles.badgeContainer}>
         <Text variant='b2' color={vars.color.text.secondary}>
           소비 상황
         </Text>
         <div className={styles.badgeList}>
           <Badge label={satisfactionLabel ?? '감정 누락'} />
-          <Badge label={evaluationLabel} size='sm' evaluationType={satisfactionEvaluationType} />
+          {satisfactionEvaluationType && evaluationLabel && (
+            <Badge label={evaluationLabel} size='sm' evaluationType={satisfactionEvaluationType} />
+          )}
         </div>
       </div>
 

--- a/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx
@@ -14,6 +14,8 @@ import {
   Badge,
   Divider,
 } from '@/shared/ui';
+import type { EvaluationType } from '@/shared/types/evaluation.types';
+import { getEvaluationLabel } from '@/features/expense/model/evaluationLabel';
 import { EXPENSE_CONSTANTS, EXPENSE_ERROR_MESSAGES } from '@/entities/expense';
 import { IcTrash } from 'public/icons';
 import { formatDate, formatNumberWithComma } from '@/shared/utils';
@@ -43,6 +45,8 @@ export interface ExpenseFormBottomSheetProps {
   satisfactionLabel?: string; //TODO: 임시
   /** 만족도 이모지 */
   satisfactionEmoji?: string; //TODO: 임시
+  /** 만족도 평가 타입 */
+  satisfactionEvaluationType?: EvaluationType;
   /** 삭제 버튼 클릭 시 콜백 */
   onDelete?: () => void;
   /** 선택 버튼 클릭 시 콜백 */
@@ -72,6 +76,7 @@ export const ExpenseFormBottomSheet = ({
   onCategorySelect,
   onMoreCategoryClick,
   satisfactionLabel,
+  satisfactionEvaluationType,
   onDelete,
   onConfirm,
   onClose,
@@ -81,6 +86,7 @@ export const ExpenseFormBottomSheet = ({
   isUsageError,
 }: ExpenseFormBottomSheetProps) => {
   const formattedAmount = amount !== undefined ? formatNumberWithComma(String(amount)) : '';
+  const evaluationLabel = getEvaluationLabel(satisfactionEvaluationType);
 
   return (
     <BaseBottomSheetTemplate>
@@ -131,7 +137,7 @@ export const ExpenseFormBottomSheet = ({
         </Text>
         <div className={styles.badgeList}>
           <Badge label={satisfactionLabel ?? '감정 누락'} />
-          {/* <Badge label='정말 만족했어요' size='lg' evaluationType='VERY_SATISFIED' /> */}
+          <Badge label={evaluationLabel} size='sm' evaluationType={satisfactionEvaluationType} />
         </div>
       </div>
 

--- a/apps/web/src/features/onboarding/config/steps.home.ts
+++ b/apps/web/src/features/onboarding/config/steps.home.ts
@@ -7,7 +7,7 @@ export const HOME_STEPS: OnboardingStep[] = [
   {
     key: 'plus-btn',
     title: '소비기록',
-    stepOrder: '(1/3)',
+    stepOrder: '(1/2)',
     desc: '플러스 버튼을 눌러, 소비를 기록해 보세요',
     direction: 'bottom',
     arrow: 'right',
@@ -16,19 +16,19 @@ export const HOME_STEPS: OnboardingStep[] = [
   {
     key: 'banner',
     title: '소비 돌아보기',
-    stepOrder: '(2/3)',
+    stepOrder: '(2/2)',
     desc: '소비를 돌아보며 나의 만족도를 기록할 수 있어요',
     direction: 'top',
     arrow: 'right',
     tooltipOffset: { x: '18.8rem', y: '0rem' },
   },
-  {
-    key: 'nav-toggle',
-    title: '소비 분석 리포트',
-    stepOrder: '(3/3)',
-    desc: '내 소비 만족도를 리포트로 한눈에 볼 수 있어요',
-    direction: 'bottom',
-    arrow: 'center',
-    tooltipOffset: { x: '7.6rem', y: '0rem' },
-  },
+  // {
+  //   key: 'nav-toggle',
+  //   title: '소비 분석 리포트',
+  //   stepOrder: '(3/3)',
+  //   desc: '내 소비 만족도를 리포트로 한눈에 볼 수 있어요',
+  //   direction: 'bottom',
+  //   arrow: 'center',
+  //   tooltipOffset: { x: '7.6rem', y: '0rem' },
+  // },
 ];

--- a/apps/web/src/features/retrospectBanner/model/useDailyAverageSatisfaction.ts
+++ b/apps/web/src/features/retrospectBanner/model/useDailyAverageSatisfaction.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getDailyAverageSatisfaction } from '@/entities/expenseReport';
+import type { BannerCompletedRating } from '@/shared/ui/banner';
+
+const mapTextToRating = (text?: string | null): BannerCompletedRating | null => {
+  if (!text) return null;
+  const normalized = text.replace(/\./g, '').trim();
+
+  switch (normalized) {
+    case '정말 만족했어요':
+      return 5;
+    case '대체로 만족해요':
+      return 4;
+    case '그냥 그랬어요':
+      return 3;
+    case '조금 아쉬워요':
+      return 2;
+    case '별로였어요':
+      return 1;
+    default:
+      return null;
+  }
+};
+
+interface UseDailyAverageSatisfactionParams {
+  /** yyyy-MM-dd 형식의 날짜 문자열 (예: 2026-02-24) */
+  date?: string;
+  /** 회고 완료 여부 (true일 때만 API 호출) */
+  enabled?: boolean;
+}
+
+export const useDailyAverageSatisfaction = ({
+  date,
+  enabled = false,
+}: UseDailyAverageSatisfactionParams) => {
+  const query = useQuery({
+    queryKey: ['dailyAverageSatisfaction', date],
+    queryFn: () => getDailyAverageSatisfaction(date!),
+    enabled: enabled && !!date,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const rating = useMemo<BannerCompletedRating | null>(() => {
+    const text = query.data?.result ?? null;
+    return mapTextToRating(text);
+  }, [query.data?.result]);
+
+  return {
+    rating,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error,
+  };
+};

--- a/apps/web/src/features/retrospectBanner/model/useRetrospectBannerProps.ts
+++ b/apps/web/src/features/retrospectBanner/model/useRetrospectBannerProps.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useDailyAverageSatisfaction } from './useDailyAverageSatisfaction';
 
 type UseRetrospectBannerPropsParams = {
   selectedDate: Date | null;
@@ -16,6 +17,7 @@ type BannerProps =
       title?: string;
       subText?: string;
       dateLabel?: string;
+      completedRating?: undefined;
     }
   | {
       isActive: true;
@@ -23,6 +25,7 @@ type BannerProps =
       title: string;
       subText?: string;
       dateLabel?: string;
+      completedRating?: undefined;
     };
 
 const isSameDay = (a: Date, b: Date) =>
@@ -42,8 +45,20 @@ export const useRetrospectBannerProps = ({
   retrospectCompleted,
   bannerMessage,
   bannerSubMessage,
-}: UseRetrospectBannerPropsParams): BannerProps =>
-  useMemo(() => {
+}: UseRetrospectBannerPropsParams): BannerProps | (BannerProps & { completedRating: number }) => {
+  const today = new Date();
+  const baseDate = dailyDate ? new Date(dailyDate) : (selectedDate ?? today);
+  const dateStr = `${baseDate.getFullYear()}-${String(baseDate.getMonth() + 1).padStart(
+    2,
+    '0'
+  )}-${String(baseDate.getDate()).padStart(2, '0')}`;
+
+  const { rating } = useDailyAverageSatisfaction({
+    date: dateStr,
+    enabled: !!retrospectCompleted,
+  });
+
+  return useMemo(() => {
     const today = new Date();
     const baseDate = dailyDate ? new Date(dailyDate) : (selectedDate ?? today);
 
@@ -52,7 +67,7 @@ export const useRetrospectBannerProps = ({
 
     // 오늘인 경우: Banner의 today 기본 카피를 그대로 사용
     if (isToday) {
-      return { isActive: false };
+      return { isActive: false } as BannerProps;
     }
 
     // 오늘이 아니고, 소비가 전혀 없는 경우
@@ -63,14 +78,35 @@ export const useRetrospectBannerProps = ({
         title: `${dateLabel}의 소비가 남겨지지 않았어요`,
         subText: '소비를 기록한 뒤 만족도를 남겨보세요',
         dateLabel,
-      };
+      } as BannerProps;
     }
 
-    // 오늘이 아니고, 소비가 있는 경우 → API에서 내려준 카피 사용
+    // 오늘이 아니고, 소비가 있는 경우
+    // - 회고 미완료: 기존 카피 사용
+    // - 회고 완료 + 일별 종합 만족도 존재: completedRating으로 성공 배너 표시
+    if (retrospectCompleted && rating) {
+      return {
+        isActive: false,
+        title: bannerMessage ?? `${dateLabel}의 소비, 지금은 어떤가요?`,
+        subText: bannerSubMessage ?? undefined,
+        dateLabel,
+        completedRating: rating,
+      } as BannerProps & { completedRating: number };
+    }
+
     return {
       isActive: !retrospectCompleted,
       title: bannerMessage ?? `${dateLabel}의 소비, 지금은 어떤가요?`,
       subText: bannerSubMessage ?? undefined,
       dateLabel,
-    };
-  }, [selectedDate, dailyDate, hasExpenses, retrospectCompleted, bannerMessage, bannerSubMessage]);
+    } as BannerProps;
+  }, [
+    selectedDate,
+    dailyDate,
+    hasExpenses,
+    retrospectCompleted,
+    bannerMessage,
+    bannerSubMessage,
+    rating,
+  ]);
+};

--- a/apps/web/src/features/review/model/useSpendingReview.ts
+++ b/apps/web/src/features/review/model/useSpendingReview.ts
@@ -59,6 +59,7 @@ export const useSpendingReview = ({ date }: UseSpendingReviewParams): UseSpendin
     mutationFn: patchRemind,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: entityExpenseQueries.all });
+      queryClient.invalidateQueries({ queryKey: ['dailyAverageSatisfaction'] });
       toast.success('만족도 기록이 잘 저장되었어요!');
       router.push(ROUTES.HOME);
     },

--- a/apps/web/src/shared/ui/badge/Badge.css.ts
+++ b/apps/web/src/shared/ui/badge/Badge.css.ts
@@ -45,4 +45,6 @@ export const iconWrapper = style({
   alignItems: 'center',
   justifyContent: 'center',
   padding: '0.13rem',
+  width: '1.33rem',
+  height: '1.33rem',
 });

--- a/apps/web/src/shared/ui/banner/Banner.tsx
+++ b/apps/web/src/shared/ui/banner/Banner.tsx
@@ -21,7 +21,7 @@ type BannerIconState = 'today' | 'success1' | 'success2' | 'success3' | 'success
 const SUCCESS_TITLES: Record<BannerCompletedRating, string> = {
   1: '별로인 소비였어요',
   2: '조금 아쉬운 소비였어요',
-  3: '그냥 그랬던 소비였어요',
+  3: '그냥 그런 소비였어요',
   4: '대체로 만족한 소비였어요',
   5: '정말 만족한 소비였어요',
 };

--- a/apps/web/src/shared/ui/bottomNav/BottomNav.css.ts
+++ b/apps/web/src/shared/ui/bottomNav/BottomNav.css.ts
@@ -12,9 +12,17 @@ export const container = style({
   padding: `${vars.spacing.md} ${vars.spacing.xl}`,
   backgroundColor: 'transparent',
   zIndex: 100,
+
+  // 네비게이션 토글은 2차 배포에서 숨김 처리되어 있기 때문에 터치를 받지 않도록 한다.
+  // TODO: 2차 배포 완료 후 숨김 처리 해제
+  pointerEvents: 'none',
 });
 
 export const plusButtonWrapper = style({
   position: 'absolute',
   right: vars.spacing.xl,
+
+  // 컨테이너에 pointer-events: 'none'을 주었기 때문에
+  // 실제로 클릭 가능한 플러스 버튼 영역만 터치를 받도록 수정
+  pointerEvents: 'auto',
 });

--- a/apps/web/src/shared/ui/navToggle/NavToggle.css.ts
+++ b/apps/web/src/shared/ui/navToggle/NavToggle.css.ts
@@ -14,6 +14,10 @@ export const container = style({
   border: `0.6px solid ${vars.color.bg.neutral}`,
   boxShadow: vars.shadow.shadow1,
   position: 'relative',
+
+  // 2차 배포에선 숨김 처리
+  opacity: 0,
+  pointerEvents: 'none',
 });
 
 export const itemsRow = style({

--- a/apps/web/src/widgets/report/model/toReportSummaryVM.ts
+++ b/apps/web/src/widgets/report/model/toReportSummaryVM.ts
@@ -18,14 +18,14 @@ export function toReportSummaryVM(params: {
 
   const totalCount = rankItems.reduce((sum, item) => sum + item.count, 0);
 
-  // 개수(count) 내림차순 정렬
-  const sortedByCount = [...rankItems].sort((a, b) => {
-    if (b.count !== a.count) return b.count - a.count;
-    return b.amount - a.amount;
+  // 금액(amount) 내림차순 정렬 (동률이면 count로 정렬)
+  const sortedByAmount = [...rankItems].sort((a, b) => {
+    if (b.amount !== a.amount) return b.amount - a.amount;
+    return b.count - a.count;
   });
   // 상위 4개 → 막대 그래프, 상위 3개 → 순위 리스트
-  const barItems = sortedByCount.slice(0, 4);
-  const listItems = sortedByCount.slice(0, 3);
+  const barItems = sortedByAmount.slice(0, 4);
+  const listItems = sortedByAmount.slice(0, 3);
 
   return {
     title,

--- a/apps/web/src/widgets/report/ui/ReportSummaryCard/ReportSummaryCard.css.ts
+++ b/apps/web/src/widgets/report/ui/ReportSummaryCard/ReportSummaryCard.css.ts
@@ -139,23 +139,30 @@ export const rankCountIcon = style({
   color: vars.color.icon.card,
 });
 
+export const rankDotWrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  margin: '0.3rem',
+});
+
+const rankDotBase = {
+  width: '1.4rem',
+  height: '1.4rem',
+  borderRadius: vars.radius.full,
+} as const;
+
 export const rankDot = styleVariants({
   0: {
-    width: '1.4rem',
-    height: '1.4rem',
-    borderRadius: vars.radius.full,
+    ...rankDotBase,
     backgroundColor: vars.color.bg.reportSummary.bar.strong,
   },
   1: {
-    width: '1.4rem',
-    height: '1.4rem',
-    borderRadius: vars.radius.full,
+    ...rankDotBase,
     backgroundColor: vars.color.bg.reportSummary.bar.medium,
   },
   2: {
-    width: '1.4rem',
-    height: '1.4rem',
-    borderRadius: vars.radius.full,
+    ...rankDotBase,
     backgroundColor: vars.color.bg.reportSummary.bar.light,
   },
 });

--- a/apps/web/src/widgets/report/ui/ReportSummaryCard/ReportSummaryCard.tsx
+++ b/apps/web/src/widgets/report/ui/ReportSummaryCard/ReportSummaryCard.tsx
@@ -67,7 +67,9 @@ export const ReportSummaryCard = ({
                       {row.index}
                     </Text>
                   </div>
-                  <span className={styles.rankDot[row.dotIndex]} />
+                  <div className={styles.rankDotWrapper}>
+                    <div className={styles.rankDot[row.dotIndex]} />
+                  </div>
                   <div className={styles.rankLabelTextWrapper}>
                     <p className={styles.rankLabelText}>{row.label}</p>
                     <IcClear className={styles.rankCountIcon} aria-hidden />


### PR DESCRIPTION
## 📝 PR 유형

* [x] 🚀 feature 기능 추가
* [ ] 🐞 버그 발생
* [x] 🔨 리팩토링
* [ ] 📋 문서작성
* [ ] 🌍 빌드 설정 및 문제
* [ ] ETC

## 🔔 관련된 이슈 넘버

close #180

## ✅ 작업 목록

### 1️⃣ 바텀시트 만족도 Badge 연동

#### evaluationType → 바텀시트 만족도 뱃지 연동 및 라벨 매핑 분리

**1) 데이터 플로우 연결**

* `ExpenseEditBottomSheet → ExpenseFormBottomSheet`로 `satisfactionEvaluationType` 전달

  ```tsx
  satisfactionEvaluationType={expense?.evaluationType}
  ```
* 일별 조회 API에서 내려오는 `expense.evaluationType`이 편집 바텀시트까지 그대로 전달되도록 연결

**2) Badge에 evaluationType 주입**

* 작은 만족도 배지에 `evaluationType={satisfactionEvaluationType}` 주입
* 배지 스타일/상태가 evaluationType 기준으로 렌더링되도록 변경

**3) 평가 타입 → 라벨 매핑 로직 분리 (FSD model)**

* 컴포넌트 내부에 있던 라벨 매핑을 `features/expense/model`로 이동
* `getEvaluationLabel(evaluationType)` 유틸 추가
* UI는 타입만 받고 라벨은 model에서 변환하도록 단순화

```tsx
const EVALUATION_LABEL_MAP: Record<EvaluationType, string> = {
  VERY_SATISFIED: '정말 만족했어요',
  SATISFIED: '만족했어요',
  NORMAL: '그냥 그랬어요',
  DISAPPOINTED: '조금 아쉬웠어요',
  VERY_DISAPPOINTED: '정말 별로였어요',
};

export const getEvaluationLabel = (evaluationType: EvaluationType): string => {
  return EVALUATION_LABEL_MAP[evaluationType];
};
```

**4) 하드코딩 제거**

* 배지 라벨을 직접 문자열로 쓰지 않고

  ```tsx
  getEvaluationLabel(satisfactionEvaluationType)
  ```

  결과를 label로 사용하도록 수정

#### 변경 후 동작

* API 응답:

  ```json
  { "evaluationType": "VERY_SATISFIED" }
  ```
* 편집 바텀시트

  * 배지 label: “정말 만족했어요”
  * 배지 스타일: evaluationType 기준 렌더링

#### FSD 관점 정리

* UI: 표시만 담당
* features/expense/model: 도메인 값 → 표시 문구 변환 책임
* shared/types의 `EvaluationType` 유지 → 타입 일관성 강화

---

### 2️⃣ 배너 – 일별 평균 만족도 API 연동

#### 1) 일별 종합 만족도 API 신규 연동

* `getDailyAverageSatisfaction` API 래퍼 추가
  (`entities/expenseReport/api/getDailyAverageSatisfaction.ts`)
* expenseReport index export 추가
* `useDailyAverageSatisfaction` 훅 신규 생성

**동작**

* `GET /api/expense/daily_satisfaction?date=yyyy-MM-dd`
* 응답 문자열을 내부 점수 체계로 변환

  * "별로였어요" → 1
  * "정말 만족했어요" → 5
* react-query로 캐싱 및 로딩 관리

---

#### 2) 홈 배너 회고 완료 상태 연동

* `useRetrospectBannerProps`에서 `useDailyAverageSatisfaction` 사용
* `retrospectCompleted === true`인 경우:

  * 평균 만족도 → `completedRating` 변환
  * Banner 성공 모드 전환

**결과**

* 배너 이모지/문구가 평균 만족도에 맞게 변경
* 버튼 자동 숨김 처리

---

#### 3) 만족도 라벨 유틸 안정성 강화

* `getEvaluationLabel`에서 기본값 반환 제거
* 반드시 `EvaluationType`이 있어야 라벨 반환

→ 암묵적 fallback 제거
→ 타입 안정성 강화

---

#### 4) 지출 편집 바텀시트 “소비 상황” 영역 개선

* TODO 주석 제거
* 두 번째 만족도 뱃지는 `satisfactionEvaluationType` 존재 시에만 렌더

**결과**

* 타입이 없으면 두 번째 뱃지만 숨김
* 타이틀 + 첫 번째 감정 뱃지는 항상 유지
* UI 안정성 개선

---

#### 5) 리뷰 완료 후 배너 즉시 리페치 처리

`useSpendingReview` mutation 성공 시

기존:

```tsx
entityExpenseQueries.all invalidate
```

추가:

```tsx
['dailyAverageSatisfaction'] invalidate
```

**결과**

* 리뷰 완료 → 홈 복귀 시
* 배너 평균 만족도 / 이모지 / 문구 즉시 갱신
* 상태 싱크 문제 해결


## 🍰 논의사항



## 📷 ETC
리포트 탭 아직 개발이 완료되지 않아 하단 Nav Toggle 숨김처리 및 홈 온보딩 step 중 Nav Toggle도 제외했습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 일일 만족도 평가 기능 추가
  * 지출 평가 유형 배지 표시 추가

* **UI/UX Improvements**
  * 내비게이션 토글 숨김 처리
  * 배지 아이콘 크기 조정
  * 리포트 카드 순위 표시 개선
  * 하단 내비게이션 클릭 영역 최적화

* **Chores**
  * 온보딩 단계 업데이트 (3단계 → 2단계)
  * 보고서 정렬 로직 개선 (금액 기준 정렬)
  * 만족도 레이블 텍스트 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->