### PR TITLE
Refactor: 2차 QA 반영 (홈 일별 소비 만족도 뱃지 및 로딩/빈 상태 UX 개선)

### DIFF
--- a/apps/web/src/features/expense-summary/model/useExpenseSummaryData.ts
+++ b/apps/web/src/features/expense-summary/model/useExpenseSummaryData.ts
@@ -41,17 +41,31 @@ export const useExpenseSummaryData = ({ monthDate, dayDate }: UseExpenseSummaryD
     const total = expenses.reduce((sum: number, exp: ExpenseListDTO) => sum + (exp.amount ?? 0), 0);
     const count = expenses.length;
 
+    /**
+     * hasExpenses(일별 API 플래그)와 월별 총액을 함께 사용해서
+     * 한 번이라도 지출한 적이 있으면 'never'(첫 소비) 상태가 나오지 않도록 보정
+     */
+    const hasEverExpenses = hasExpenses || monthlyTotalAmount > 0;
+
     const getEmptyStateType = (): EmptyStateType => {
-      if (!hasExpenses) return 'never';
+      const today = new Date();
+      const selected = stableDayDate;
+      const isToday =
+        selected.getFullYear() === today.getFullYear() &&
+        selected.getMonth() === today.getMonth() &&
+        selected.getDate() === today.getDate();
+
+      // 아직까지 단 한 번도 지출 내역이 없을 때만,
+      // 오늘 날짜에서 '첫 소비' 문구를 노출하고
+      // 과거/미래 날짜에서는 일반 빈 상태 문구를 노출
+      if (!hasEverExpenses) {
+        return isToday ? 'never' : 'date';
+      }
+
       if (expenses.length === 0) {
-        const today = new Date();
-        const selected = stableDayDate;
-        const isToday =
-          selected.getFullYear() === today.getFullYear() &&
-          selected.getMonth() === today.getMonth() &&
-          selected.getDate() === today.getDate();
         return isToday ? 'today' : 'date';
       }
+
       return 'date';
     };
 
@@ -60,7 +74,7 @@ export const useExpenseSummaryData = ({ monthDate, dayDate }: UseExpenseSummaryD
       expenseCount: count,
       emptyStateType: getEmptyStateType(),
     };
-  }, [expenses, hasExpenses, stableDayDate]);
+  }, [expenses, hasExpenses, stableDayDate, monthlyTotalAmount]);
 
   return {
     monthlyTotalAmount,

--- a/apps/web/src/features/expense-summary/model/useExpenseSummaryData.ts
+++ b/apps/web/src/features/expense-summary/model/useExpenseSummaryData.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { expenseQueries } from '@/entities/expense';
 import type { ExpenseListDTO, DailyExpenseResponseDTO, EmptyStateType } from '@/entities/expense';
@@ -18,8 +18,42 @@ export const useExpenseSummaryData = ({ monthDate, dayDate }: UseExpenseSummaryD
   const year = monthDate.getFullYear();
   const month = monthDate.getMonth() + 1;
 
-  /** 쿼리 키/캐시 안정화: dayDate가 없을 때 매 렌더 new Date() 대신 monthDate 사용 */
-  const stableDayDate = dayDate ?? monthDate;
+  /**
+   * 쿼리 키/캐시 안정화 + 월 전환 중 깜빡임 방지
+   *
+   * - dayDate를 명시적으로 쓰지 않는 경우(undefined): 항상 monthDate 기준으로 동기화
+   * - dayDate를 쓰는 경우:
+   *   - 일자가 선택되어 있을 때(Date): 해당 날짜로 고정
+   *   - 월 스와이프 중 잠시 null이 되는 구간: 직전 선택 날짜를 그대로 유지해서
+   *     "이번 달 1일"로 잠깐 갔다 오는 중간 쿼리가 일어나지 않도록 함
+   */
+  const [stableDayDate, setStableDayDate] = useState<Date>(() => dayDate ?? monthDate);
+  const hasEverNonNullDayDateRef = useRef(false);
+
+  useEffect(() => {
+    if (dayDate && !hasEverNonNullDayDateRef.current) {
+      hasEverNonNullDayDateRef.current = true;
+    }
+
+    // dayDate를 사용하지 않는 호출(useExpenseSummaryData({ monthDate }))은 항상 monthDate를 따름
+    if (dayDate === undefined) {
+      setStableDayDate(monthDate);
+      return;
+    }
+
+    // 명시적으로 선택된 날짜가 있을 때는 해당 날짜로 고정
+    if (dayDate) {
+      setStableDayDate(dayDate);
+      return;
+    }
+
+    // dayDate가 null인 경우:
+    // - 한 번도 날짜 선택이 없었다면(month-only 사용 패턴) monthDate 기준으로 따라가고
+    // - 한 번이라도 날짜 선택이 있었다면(달력 스와이프 중) 직전 stableDayDate를 유지
+    if (!hasEverNonNullDayDateRef.current) {
+      setStableDayDate(monthDate);
+    }
+  }, [dayDate, monthDate]);
 
   const calendarQuery = useQuery(expenseQueries.calendarExpense(year, month));
   const dailyQuery = useQuery(expenseQueries.dailyExpense(stableDayDate));
@@ -76,6 +110,11 @@ export const useExpenseSummaryData = ({ monthDate, dayDate }: UseExpenseSummaryD
     };
   }, [expenses, hasExpenses, stableDayDate, monthlyTotalAmount]);
 
+  const isMonthlyLoading = calendarQuery.isLoading;
+  const isMonthlyFetching = calendarQuery.isFetching;
+  const isDailyLoading = dailyQuery.isLoading;
+  const isDailyFetching = dailyQuery.isFetching;
+
   return {
     monthlyTotalAmount,
     expenses,
@@ -83,8 +122,14 @@ export const useExpenseSummaryData = ({ monthDate, dayDate }: UseExpenseSummaryD
     expenseCount,
     dailyTotalAmount,
     emptyStateType,
-    isLoading: calendarQuery.isLoading || dailyQuery.isLoading,
-    isFetching: calendarQuery.isFetching || dailyQuery.isFetching,
+    // 일별 영역 전용 로딩 플래그 (리스트/배너 등)
+    isLoading: isDailyLoading,
+    isFetching: isDailyFetching,
+    // 월별 영역 전용 로딩 플래그 (헤더/리포트 등)
+    isMonthlyLoading,
+    isMonthlyFetching,
+    isDailyLoading,
+    isDailyFetching,
     error: calendarQuery.error || dailyQuery.error,
     bannerMessage,
     bannerSubMessage,

--- a/apps/web/src/features/expense/model/evaluationLabel.ts
+++ b/apps/web/src/features/expense/model/evaluationLabel.ts
@@ -1,13 +1,6 @@
-import type { EvaluationType } from '@/shared/types/evaluation.types';
-
-const EVALUATION_LABEL_MAP: Record<EvaluationType, string> = {
-  VERY_SATISFIED: '정말 만족했어요',
-  SATISFIED: '만족했어요',
-  NORMAL: '그냥 그랬어요',
-  DISAPPOINTED: '조금 아쉬웠어요',
-  VERY_DISAPPOINTED: '정말 별로였어요',
-};
-
-export const getEvaluationLabel = (evaluationType: EvaluationType): string => {
-  return EVALUATION_LABEL_MAP[evaluationType];
-};
+/**
+ * @deprecated
+ * 실제 구현은 shared/lib/evaluationLabel.ts에 있음.
+ * FSD 규칙 위반이기에 추후 이 파일은 삭제 예정입니다.
+ */
+export { getEvaluationLabel } from '@/shared/lib/evaluationLabel';

--- a/apps/web/src/features/expense/model/evaluationLabel.ts
+++ b/apps/web/src/features/expense/model/evaluationLabel.ts
@@ -1,6 +1,0 @@
-/**
- * @deprecated
- * 실제 구현은 shared/lib/evaluationLabel.ts에 있음.
- * FSD 규칙 위반이기에 추후 이 파일은 삭제 예정입니다.
- */
-export { getEvaluationLabel } from '@/shared/lib/evaluationLabel';

--- a/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
@@ -57,6 +57,7 @@ export const ExpenseEditBottomSheet = ({
   const [amountError, setAmountError] = useState<string | undefined>(undefined);
 
   const isValidNameRegex = /^[가-힣a-zA-Z0-9\s]*$/;
+  const isUsageEmpty = usage.trim().length === 0;
   const isUsageInvalid = usage !== '' && !isValidNameRegex.test(usage);
 
   // 카테고리 목록 조회
@@ -228,12 +229,10 @@ export const ExpenseEditBottomSheet = ({
         onMoreCategoryClick={() => setIsCategorySheetOpen(true)}
         satisfactionLabel={expense?.emotionType ?? '감정 누락'}
         satisfactionEvaluationType={expense?.evaluationType}
-        confirmDisabled={
-          amount <= 0 || !usage || usage.trim().length === 0 || !!amountError || isUsageInvalid
-        }
+        confirmDisabled={amount <= 0 || isUsageEmpty || !!amountError || isUsageInvalid}
         amountErrorMessage={amountError}
         isAmountError={!!amountError}
-        isUsageError={isUsageInvalid}
+        isUsageError={isUsageEmpty || isUsageInvalid}
       />
       <AlertDialog
         isOpen={isDeleteDialogOpen}

--- a/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx
@@ -85,10 +85,16 @@ export const ExpenseFormBottomSheet = ({
   isAmountError,
   isUsageError,
 }: ExpenseFormBottomSheetProps) => {
+  const [isAmountFocused, setIsAmountFocused] = React.useState(false);
+  const [isUsageFocused, setIsUsageFocused] = React.useState(false);
+
   const formattedAmount = amount !== undefined ? formatNumberWithComma(String(amount)) : '';
   const evaluationLabel = satisfactionEvaluationType
     ? getEvaluationLabel(satisfactionEvaluationType)
     : null;
+
+  const showAmountError = !!isAmountError && !isAmountFocused;
+  const showUsageError = !!isUsageError && !isUsageFocused;
 
   return (
     <BaseBottomSheetTemplate>
@@ -100,8 +106,10 @@ export const ExpenseFormBottomSheet = ({
           value={formattedAmount}
           onValueChange={onAmountChange}
           fieldType='number'
-          errorMessage={amountErrorMessage}
-          error={isAmountError}
+          errorMessage={showAmountError ? amountErrorMessage : undefined}
+          error={showAmountError}
+          onFocus={() => setIsAmountFocused(true)}
+          onBlur={() => setIsAmountFocused(false)}
         />
       </InputField>
 
@@ -112,9 +120,11 @@ export const ExpenseFormBottomSheet = ({
             placeholder='사용처를 입력해주세요'
             value={usage}
             onValueChange={onUsageChange}
-            errorMessage={EXPENSE_ERROR_MESSAGES.INVALID_USAGE}
-            error={isUsageError}
+            errorMessage={showUsageError ? EXPENSE_ERROR_MESSAGES.INVALID_USAGE : undefined}
+            error={showUsageError}
             maxLength={EXPENSE_CONSTANTS.MAX_USAGE_LENGTH}
+            onFocus={() => setIsUsageFocused(true)}
+            onBlur={() => setIsUsageFocused(false)}
           />
         </InputField>
       </div>

--- a/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx
@@ -15,7 +15,7 @@ import {
   Divider,
 } from '@/shared/ui';
 import type { EvaluationType } from '@/shared/types/evaluation.types';
-import { getEvaluationLabel } from '@/features/expense/model/evaluationLabel';
+import { getEvaluationLabel } from '@/shared/lib/evaluationLabel';
 import { EXPENSE_CONSTANTS, EXPENSE_ERROR_MESSAGES } from '@/entities/expense';
 import { IcTrash } from 'public/icons';
 import { formatDate, formatNumberWithComma } from '@/shared/utils';

--- a/apps/web/src/shared/lib/evaluationLabel.ts
+++ b/apps/web/src/shared/lib/evaluationLabel.ts
@@ -1,0 +1,13 @@
+import type { EvaluationType } from '@/shared/types/evaluation.types';
+
+const EVALUATION_LABEL_MAP: Record<EvaluationType, string> = {
+  VERY_SATISFIED: '정말 만족했어요',
+  SATISFIED: '대체로 만족했어요',
+  NORMAL: '그냥 그랬어요',
+  DISAPPOINTED: '조금 아쉬웠어요',
+  VERY_DISAPPOINTED: '별로였어요',
+};
+
+export const getEvaluationLabel = (evaluationType: EvaluationType): string => {
+  return EVALUATION_LABEL_MAP[evaluationType];
+};

--- a/apps/web/src/shared/ui/banner/Banner.tsx
+++ b/apps/web/src/shared/ui/banner/Banner.tsx
@@ -4,6 +4,7 @@ import React, { HTMLAttributes } from 'react';
 import * as styles from './Banner.css';
 import { Text } from '../text';
 import { vars } from '../theme.css';
+import { blinkingText } from '../animations/loading.css';
 import {
   IcRightChevron,
   IcGrayNormal,
@@ -53,6 +54,8 @@ export interface BannerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'class
   dateLabel?: string;
   /** 돌아보기 버튼 클릭 핸들러 */
   onClickReview?: () => void;
+  /** 배너 내용 로딩 상태 여부 (텍스트 깜빡임 애니메이션 표시) */
+  isLoading?: boolean;
 }
 
 const NO_SPENDING_SUBTEXT = '소비를 기록한 뒤 만족도를 남겨보세요';
@@ -66,6 +69,7 @@ export const Banner = ({
   subText: subTextProp,
   dateLabel,
   onClickReview,
+  isLoading,
   ...props
 }: BannerProps) => {
   const isSuccess = completedRating != null && completedRating >= 1 && completedRating <= 5;
@@ -75,7 +79,12 @@ export const Banner = ({
   let iconWrapperState: BannerIconState = 'today';
   let buttonVariant: 'disabled' | 'active' | 'hidden';
 
-  if (isSuccess) {
+  if (isLoading) {
+    title = titleProp ?? '소비 데이터를 불러오는 중이에요';
+    subText = subTextProp ?? '잠시만 기다려주세요';
+    iconWrapperState = 'today';
+    buttonVariant = 'disabled';
+  } else if (isSuccess) {
     title = SUCCESS_TITLES[completedRating!];
     subText = SUCCESS_SUBTEXT;
     iconWrapperState = `success${completedRating}` as BannerIconState;
@@ -107,10 +116,16 @@ export const Banner = ({
           <EmojiIcon className={styles.emojiIcon} />
         </div>
         <div className={styles.textWrapper}>
-          <Text variant='b3' color={vars.color.text.primary}>
+          <Text
+            variant='b3'
+            color={vars.color.text.primary}
+            className={isLoading ? blinkingText : undefined}>
             {title}
           </Text>
-          <Text variant='b1' color={vars.color.text.tertiary}>
+          <Text
+            variant='b1'
+            color={vars.color.text.tertiary}
+            className={isLoading ? blinkingText : undefined}>
             {subText}
           </Text>
         </div>

--- a/apps/web/src/shared/ui/historyCard/HistoryCard.css.ts
+++ b/apps/web/src/shared/ui/historyCard/HistoryCard.css.ts
@@ -31,3 +31,8 @@ export const labelWrapper = style({
   alignItems: 'flex-start',
   gap: spacing.sm,
 });
+
+// Figma: Home 소비 기록 카드 내 만족도 뱃지(node-id 5068-83692) 위치/간격을 맞추기 위한 래퍼
+export const badgeWrapper = style({
+  marginTop: spacing.xs2,
+});

--- a/apps/web/src/shared/ui/historyCard/HistoryCard.tsx
+++ b/apps/web/src/shared/ui/historyCard/HistoryCard.tsx
@@ -4,8 +4,10 @@ import React, { HTMLAttributes } from 'react';
 import * as styles from './HistoryCard.css';
 import { CategoryBtn, CategoryIconType } from '../categoryBtn';
 import { Text } from '../text';
-// import { Badge } from '../badge';
+import { Badge } from '../badge';
 import { vars } from '../theme.css';
+import type { EvaluationType } from '@/shared/types/evaluation.types';
+import { getEvaluationLabel } from '@/shared/lib/evaluationLabel';
 
 export interface HistoryCardProps extends Omit<HTMLAttributes<HTMLDivElement>, 'className'> {
   /** 소비처 제목 */
@@ -16,6 +18,8 @@ export interface HistoryCardProps extends Omit<HTMLAttributes<HTMLDivElement>, '
   price: number;
   /** 카테고리 이름 (예: 식비) */
   categoryName?: string;
+  /** 소비 만족도 평가 타입 */
+  evaluationType?: EvaluationType | null;
   disabled?: boolean;
 }
 
@@ -24,10 +28,13 @@ export const HistoryCard = ({
   category,
   price,
   categoryName,
+  evaluationType,
   onClick,
   disabled = false,
   ...props
 }: HistoryCardProps) => {
+  const evaluationLabel = evaluationType ? getEvaluationLabel(evaluationType) : null;
+
   return (
     <div
       className={styles.historyCardWrapper}
@@ -49,6 +56,11 @@ export const HistoryCard = ({
               </Text>
             )}
           </div>
+          {evaluationType && evaluationLabel && (
+            <div className={styles.badgeWrapper}>
+              <Badge label={evaluationLabel} size='xs' evaluationType={evaluationType} />
+            </div>
+          )}
         </div>
       </div>
       <Text variant='b4' color={vars.color.text.primary} align='center' as='div'>

--- a/apps/web/src/widgets/home/ui/ExpenseList/ExpenseList.tsx
+++ b/apps/web/src/widgets/home/ui/ExpenseList/ExpenseList.tsx
@@ -20,6 +20,7 @@ export const ExpenseList = ({ expenses = [], onExpenseClick }: ExpenseListProps)
           category={expense.categoryIconType ?? 'coin'}
           price={expense.amount ?? 0}
           categoryName={expense.categoryName ?? ''}
+          evaluationType={expense.evaluationType ?? null}
           onClick={() => onExpenseClick?.(expense)}
         />
       ))}

--- a/apps/web/src/widgets/home/ui/Home.tsx
+++ b/apps/web/src/widgets/home/ui/Home.tsx
@@ -63,8 +63,10 @@ export const Home = ({
     expenseCount,
     dailyTotalAmount,
     emptyStateType,
-    isLoading,
-    isFetching,
+    isMonthlyLoading,
+    isMonthlyFetching,
+    isDailyLoading,
+    isDailyFetching,
     bannerMessage,
     bannerSubMessage,
     retrospectCompleted,
@@ -124,8 +126,8 @@ export const Home = ({
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           monthlyTotalAmount={monthlyTotalAmount}
-          isLoading={isLoading}
-          isFetching={isFetching}
+          isLoading={isMonthlyLoading}
+          isFetching={isMonthlyFetching}
         />
 
         <CalendarSection
@@ -137,7 +139,12 @@ export const Home = ({
           renderWeeklyCalendar={renderWeeklyCalendar}
           renderMonthlyCalendar={renderMonthlyCalendar}
         />
-        <Banner {...bannerProps} onClickReview={handleClickReview} data-onboarding-id='banner' />
+        <Banner
+          {...bannerProps}
+          isLoading={isDailyLoading || isDailyFetching}
+          onClickReview={handleClickReview}
+          data-onboarding-id='banner'
+        />
         <ExpenseContent
           hasExpenses={expenses.length > 0}
           emptyStateType={emptyStateType}
@@ -145,8 +152,8 @@ export const Home = ({
           totalExpenseAmount={dailyTotalAmount}
           expenses={expenses}
           onExpenseClick={handleExpenseClick}
-          isLoading={isLoading}
-          isFetching={isFetching}
+          isLoading={isDailyLoading}
+          isFetching={isDailyFetching}
         />
       </div>
 


### PR DESCRIPTION
## 📝 PR 유형

* [x] 🚀 feature 기능 추가
* [x] 🔨 리팩토링


## 🔔 관련된 이슈 넘버

close #186


## ✅ 작업 목록


## 1️⃣ 홈 일별 소비 기록에 만족도 뱃지 추가

### 1. HistoryCard에 만족도 뱃지 추가

* `evaluationType?: EvaluationType | null` prop 추가
* `getEvaluationLabel`을 사용해 라벨 계산
* `evaluationType`이 존재할 경우 `Badge size='xs'` 렌더링

**파일**

* `shared/ui/historyCard/HistoryCard.tsx`
* `shared/ui/historyCard/HistoryCard.css.ts`

추가 사항:

* Figma 시안 기준으로 뱃지 위치 조정을 위한 `badgeWrapper` 스타일 추가 (`marginTop: spacing.xs2`)

---

### 2. 홈 일별 리스트에서 evaluationType 전달

* 서버에서 내려오는 `expense.evaluationType`을 `HistoryCard`로 전달

**파일**

* `widgets/home/ui/ExpenseList/ExpenseList.tsx`

---

### 3. 만족도 라벨 유틸을 shared 레벨로 승격

* 기존: `features/expense/model/evaluationLabel.ts`
* 변경: `shared/lib/evaluationLabel.ts`

**이유**

* 여러 레이어에서 공통으로 사용하는 순수 매핑 로직
* FSD 의존성 규칙 준수 (shared → features 역의존 방지)

---

## 2️⃣ 홈 화면 요약/배너/리스트 로딩 상태 및 깜빡임 개선

## 1. useExpenseSummaryData 로직 개선

**파일**

* `features/expense-summary/model/useExpenseSummaryData.ts`

### 주요 개선 사항

* `stableDayDate` 상태 도입

  * dayDate가 null로 잠시 떨어지는 월 스와이프 구간에서
  * 쿼리가 “이번 달 1일”로 튀는 문제 방지

* 로딩 상태 분리

  * `isMonthlyLoading`, `isMonthlyFetching`
  * `isDailyLoading`, `isDailyFetching`

* 반환값 구조 개선

  * 월/일별 로딩 상태를 각각 노출
  * 일별 영역 전용 `isLoading`, `isFetching` 정리

---

## 2. 빈 상태(emptyStateType) 로직 보정

### hasEverExpenses 도입

```ts
hasEverExpenses = hasExpenses || monthlyTotalAmount > 0
```

### 개선된 emptyStateType 분기

1. 지출이 한 번도 없는 경우

   * 오늘 → `'never'`
   * 과거/미래 → `'date'`

2. 지출 경험은 있으나 해당 날짜에만 없는 경우

   * 오늘 → `'today'`
   * 그 외 → `'date'`

의도:

* 지출 경험이 있는 유저에게 더 이상 “첫 소비” 문구가 노출되지 않도록 보정

---

## 3. Home 위젯 로딩 연동

**파일**

* `widgets/home/ui/Home.tsx`

* 월별 영역 → `isMonthlyLoading`, `isMonthlyFetching`

* 일별 영역 → `isDailyLoading`, `isDailyFetching`

* `Banner`에 `isLoading={isDailyLoading || isDailyFetching}` 전달

---

## 4. Banner 로딩 상태 UX 개선

**파일**

* `shared/ui/banner/Banner.tsx`

### 변경 사항

* `isLoading?: boolean` prop 추가
* 로딩 중일 때:

  * 타이틀/서브텍스트 고정
  * 버튼 disabled 처리
  * `blinkingText` 애니메이션 적용

**관련**

* `shared/ui/animations/loading.css` 활용

---

## 3️⃣ 소비 작성/수정 바텀시트 에러 UX 개선

## 1. 입력 중일 때 에러 숨김 처리

**파일**

* `features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx`

### 추가 상태

* `isAmountFocused`
* `isUsageFocused`

### 개선 내용

* `showAmountError`, `showUsageError`로 실제 표시 여부 분리
* 포커스 중에는 에러 UI 숨김
* blur 이후에만 에러 노출

의도:

* 입력 중 계속 빨간 테두리가 유지되는 UX 개선

---

## 2. 사용처 validation 강화

**파일**

* `features/expense/ui/ExpenseEditBottomSheet.tsx`

### 추가 로직

```ts
isUsageEmpty = usage.trim().length === 0
```

### confirmDisabled 조건 강화

* amount <= 0
* isUsageEmpty
* amountError
* isUsageInvalid

중 하나라도 true이면 비활성화

### isUsageError 조건

* isUsageEmpty || isUsageInvalid

의도:

* 완전히 비어 있는 값
* 정규식 위반 값
  모두 명확하게 차단

---

## 🍰 논의사항

1. 월/일별 쿼리 분리 이후

   * 월 전환/날짜 스와이프 시 쿼리 중복이나 과도한 re-render가 없는지 추가 검증 필요

2. emptyStateType 분기 로직이 명확해졌지만

   * 추후 리포트/회고 정책 변경 시 함께 수정 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 배너에 로딩 상태 애니메이션 추가
  * 지출 내역에 만족도 평가 배지 표시 기능 추가

* **개선사항**
  * 입력 필드 오류 메시지 표시 타이밍 개선 (포커스/블러 시점)
  * 달력 네비게이션 중 날짜 선택 상태 유지 강화
  * 월간 및 일일 데이터 로딩 상태 분리

* **업데이트**
  * 만족도 평가 텍스트 레이블 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->