### PR TITLE
Feat: schema.d.ts Response 타입 lint CLI 도구 추가 (pnpm schema:lint)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:mobile": "turbo build --filter=mobile",
     "storybook": "pnpm --filter=web storybook",
     "build-storybook": "pnpm --filter=web build-storybook",
-    "svgr": "cd apps/web && pnpm dlx @svgr/cli public/icons --out-dir src/assets/icons --ext tsx --typescript --no-prettier && pnpm exec prettier --write \"src/assets/**/*.tsx\""
+    "svgr": "cd apps/web && pnpm dlx @svgr/cli public/icons --out-dir src/assets/icons --ext tsx --typescript --no-prettier && pnpm exec prettier --write \"src/assets/**/*.tsx\"",
+    "schema:lint": "pnpx tsx scripts/schema-lint/index.ts"
   },
   "devDependencies": {
     "lefthook": "^2.0.13",

--- a/scripts/schema-lint/README.md
+++ b/scripts/schema-lint/README.md
@@ -1,0 +1,97 @@
+# Schema Lint
+
+OpenAPI로 자동 생성된 `schema.d.ts`의 Response 타입 품질을 검사하는 CLI 도구입니다.
+
+## 실행 방법
+
+```bash
+# 기본 실행 (apps/web/src/shared/api/schema.d.ts 자동 참조)
+pnpm schema:lint
+
+# 특정 파일 지정
+pnpx tsx scripts/schema-lint/index.ts path/to/schema.d.ts
+```
+
+## 검사 항목
+
+### ERROR
+
+| 규칙              | 설명                                             |
+| ----------------- | ------------------------------------------------ |
+| required 필드 0개 | Response 타입에 required 필드가 하나도 없는 경우 |
+| 전체 optional     | 필드가 3개 이상인데 전부 optional인 경우         |
+
+### WARN
+
+| 규칙                    | 설명                                        |
+| ----------------------- | ------------------------------------------- |
+| 오타 의심 (사전)        | `Avarage`, `reponse` 등 흔한 오타 패턴 매칭 |
+| 유사 필드명 (편집 거리) | 같은 Response 내 1글자 차이 필드 감지       |
+
+## 출력 예시
+
+```
+Schema Lint 리포트
+==================
+
+[ERROR] WeeklyDetailReportResponse
+  전체 8개 필드가 모두 optional입니다.
+  [제안]
+    실제 항상 내려오는 필드를 required로 지정하세요.
+    Spring 사용 시: @Schema(requiredMode = REQUIRED), @NotNull
+
+[WARN] WeeklyDetailReportResponse
+  오타 의심 필드: inAvarageEvaluation
+  [제안]
+    필드명 수정: inAvarageEvaluation -> inAverageEvaluation
+
+요약
+  검사한 Response 타입: 10개
+  ERROR: 10개
+  WARN: 1개
+```
+
+## 종료 코드
+
+- ERROR가 1개 이상이면 `exit code 1` (CI 연동 시 실패 처리 가능)
+- WARN만 있으면 통과
+
+## 오타 사전 추가
+
+`constants.ts`의 `COMMON_TYPOS` 배열에 `[오타, 올바른 표기]` 쌍을 추가하면 됩니다.
+
+```typescript
+export const COMMON_TYPOS: [string, string][] = [
+  ['Avarage', 'Average'],
+  ['reponse', 'response'],
+  // 새 패턴 추가
+  ['Destory', 'Destroy'],
+];
+```
+
+## 검사 제외 설정
+
+`constants.ts`에서 제외 대상을 관리합니다.
+
+```typescript
+// 특정 타입명 제외
+export const EXCLUDED_TYPES = new Set(['Response', 'BaseResponse', 'ErrorResponse']);
+
+// 접두사 기반 제외 (ApiResponse* 래퍼 등)
+export const EXCLUDED_PREFIXES = ['ApiResponse'];
+```
+
+## 파일 구조
+
+```
+scripts/schema-lint/
+  index.ts              # CLI 진입점
+  parseSchema.ts        # TypeScript AST 기반 스키마 파서
+  types.ts              # 공통 타입 정의
+  constants.ts          # 제외 목록, 오타 사전, 임계값
+  rules/
+    responseOptionalRule.ts   # required 필드 누락 검사
+    typoRule.ts               # 오타/유사 필드명 감지
+  reporters/
+    consoleReporter.ts        # 한국어 리포트 출력
+```

--- a/scripts/schema-lint/constants.ts
+++ b/scripts/schema-lint/constants.ts
@@ -1,0 +1,54 @@
+/** 검사에서 제외할 Response 타입명 */
+export const EXCLUDED_TYPES = new Set([
+  'Response',
+  'BaseResponse',
+  'ErrorResponse',
+  'PaginationResponse',
+]);
+
+/**
+ * 검사에서 제외할 타입명 접두사
+ * ApiResponse* 래퍼는 isSuccess/code/message/result 공통 구조이므로 제외
+ */
+export const EXCLUDED_PREFIXES = ['ApiResponse'];
+
+/**
+ * 흔한 오타 사전: [오타, 올바른 표기]
+ * 필드명에 오타 문자열이 포함되어 있으면 경고
+ */
+export const COMMON_TYPOS: [string, string][] = [
+  ['Avarage', 'Average'],
+  ['avarage', 'average'],
+  ['reponse', 'response'],
+  ['Reponse', 'Response'],
+  ['reslut', 'result'],
+  ['Reslut', 'Result'],
+  ['lenght', 'length'],
+  ['Lenght', 'Length'],
+  ['coutn', 'count'],
+  ['Coutn', 'Count'],
+  ['descrption', 'description'],
+  ['Descrption', 'Description'],
+  ['categroy', 'category'],
+  ['Categroy', 'Category'],
+  ['amoutn', 'amount'],
+  ['Amoutn', 'Amount'],
+  ['staus', 'status'],
+  ['Staus', 'Status'],
+  ['titile', 'title'],
+  ['Titile', 'Title'],
+  ['mesage', 'message'],
+  ['Mesage', 'Message'],
+];
+
+/** Response 타입 이름 매칭 패턴 */
+export const RESPONSE_SUFFIX = 'Response';
+
+/** 편집 거리 기반 유사 필드 감지 임계값 (보수적) */
+export const EDIT_DISTANCE_THRESHOLD = 1;
+
+/** 편집 거리 비교 대상 최소 필드명 길이 */
+export const MIN_FIELD_LENGTH_FOR_SIMILARITY = 6;
+
+/** 전부 optional인데 ERROR로 판단할 최소 필드 수 */
+export const MIN_FIELDS_FOR_ALL_OPTIONAL_ERROR = 3;

--- a/scripts/schema-lint/index.ts
+++ b/scripts/schema-lint/index.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import { parseSchema } from './parseSchema.js';
+import { responseOptionalRule } from './rules/responseOptionalRule.js';
+import { typoRule } from './rules/typoRule.js';
+import { printReport } from './reporters/consoleReporter.js';
+import type { Diagnostic } from './types.js';
+
+/** schema.d.ts 기본 경로 (레포 루트 기준) */
+const DEFAULT_SCHEMA_PATH = 'apps/web/src/shared/api/schema.d.ts';
+
+function main(): void {
+  const schemaPath = path.resolve(process.argv[2] ?? DEFAULT_SCHEMA_PATH);
+
+  console.log(`대상 파일: ${schemaPath}`);
+
+  const responses = parseSchema(schemaPath);
+
+  if (responses.length === 0) {
+    console.log('검사 대상 Response 타입을 찾지 못했습니다.');
+    return;
+  }
+
+  // 규칙 실행
+  const diagnostics: Diagnostic[] = [...responseOptionalRule(responses), ...typoRule(responses)];
+
+  // 리포트 출력
+  printReport(diagnostics, responses.length);
+
+  // ERROR가 있으면 exit code 1
+  const hasError = diagnostics.some((d) => d.severity === 'error');
+  if (hasError) {
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/scripts/schema-lint/parseSchema.ts
+++ b/scripts/schema-lint/parseSchema.ts
@@ -1,0 +1,104 @@
+import ts from 'typescript';
+import { EXCLUDED_PREFIXES, EXCLUDED_TYPES, RESPONSE_SUFFIX } from './constants.js';
+import type { ParsedField, ParsedResponse } from './types.js';
+
+/**
+ * schema.d.ts를 TypeScript AST로 파싱하여 Response 타입 목록을 반환한다.
+ *
+ * openapi-typescript가 생성하는 두 가지 구조를 모두 지원:
+ * 1. export interface components { schemas: { XxxResponse: { ... } } }
+ * 2. interface/type XxxResponse = { ... } (독립 선언)
+ */
+export function parseSchema(filePath: string): ParsedResponse[] {
+  const program = ts.createProgram([filePath], { noEmit: true });
+  const sourceFile = program.getSourceFile(filePath);
+
+  if (!sourceFile) {
+    throw new Error(`파일을 열 수 없습니다: ${filePath}`);
+  }
+
+  const results: ParsedResponse[] = [];
+
+  ts.forEachChild(sourceFile, (node) => {
+    // 1) export interface components { schemas: { ... } }
+    if (ts.isInterfaceDeclaration(node) && node.name.text === 'components') {
+      const schemasProperty = node.members.find(
+        (m): m is ts.PropertySignature =>
+          ts.isPropertySignature(m) && ts.isIdentifier(m.name!) && m.name.text === 'schemas'
+      );
+
+      if (schemasProperty?.type && ts.isTypeLiteralNode(schemasProperty.type)) {
+        for (const member of schemasProperty.type.members) {
+          if (!ts.isPropertySignature(member) || !member.name) continue;
+          const typeName = ts.isIdentifier(member.name)
+            ? member.name.text
+            : member.name.getText(sourceFile);
+
+          if (!isTargetResponse(typeName)) continue;
+          if (!member.type || !ts.isTypeLiteralNode(member.type)) continue;
+
+          results.push({
+            name: typeName,
+            fields: extractFields(member.type, sourceFile),
+          });
+        }
+      }
+    }
+
+    // 2) interface XxxResponse { ... }
+    if (ts.isInterfaceDeclaration(node) && isTargetResponse(node.name.text)) {
+      results.push({
+        name: node.name.text,
+        fields: extractFieldsFromMembers(node.members, sourceFile),
+      });
+    }
+
+    // 3) type XxxResponse = { ... }
+    if (
+      ts.isTypeAliasDeclaration(node) &&
+      isTargetResponse(node.name.text) &&
+      ts.isTypeLiteralNode(node.type)
+    ) {
+      results.push({
+        name: node.name.text,
+        fields: extractFields(node.type, sourceFile),
+      });
+    }
+  });
+
+  return results;
+}
+
+/** Response 접미사를 가지며 제외 목록에 없는지 확인 */
+function isTargetResponse(name: string): boolean {
+  if (!name.endsWith(RESPONSE_SUFFIX)) return false;
+  if (EXCLUDED_TYPES.has(name)) return false;
+  if (EXCLUDED_PREFIXES.some((prefix) => name.startsWith(prefix))) return false;
+  return true;
+}
+
+/** TypeLiteralNode에서 필드 정보 추출 */
+function extractFields(typeLiteral: ts.TypeLiteralNode, sourceFile: ts.SourceFile): ParsedField[] {
+  return extractFieldsFromMembers(typeLiteral.members, sourceFile);
+}
+
+/** NodeArray<TypeElement>에서 필드 정보 추출 */
+function extractFieldsFromMembers(
+  members: ts.NodeArray<ts.TypeElement>,
+  sourceFile: ts.SourceFile
+): ParsedField[] {
+  const fields: ParsedField[] = [];
+
+  for (const member of members) {
+    if (!ts.isPropertySignature(member) || !member.name) continue;
+
+    const name = ts.isIdentifier(member.name) ? member.name.text : member.name.getText(sourceFile);
+
+    const optional = member.questionToken !== undefined;
+    const typeText = member.type ? member.type.getText(sourceFile) : 'unknown';
+
+    fields.push({ name, optional, typeText });
+  }
+
+  return fields;
+}

--- a/scripts/schema-lint/reporters/consoleReporter.ts
+++ b/scripts/schema-lint/reporters/consoleReporter.ts
@@ -1,0 +1,81 @@
+import type { Diagnostic } from '../types.js';
+
+/**
+ * 진단 결과를 한국어 CLI 리포트로 출력한다.
+ */
+export function printReport(diagnostics: Diagnostic[], totalResponseCount: number): void {
+  const errors = diagnostics.filter((d) => d.severity === 'error');
+  const warns = diagnostics.filter((d) => d.severity === 'warn');
+
+  console.log('');
+  console.log('Schema Lint 리포트');
+  console.log('==================');
+  console.log('');
+
+  if (diagnostics.length === 0) {
+    console.log('✅ 모든 Response 타입이 검사를 통과했습니다.');
+    console.log('');
+    printSummary(totalResponseCount, errors.length, warns.length);
+    return;
+  }
+
+  // 타입별로 그룹핑
+  const grouped = groupByType(diagnostics);
+
+  for (const [typeName, items] of grouped) {
+    const typeErrors = items.filter((d) => d.severity === 'error');
+    const typeWarns = items.filter((d) => d.severity === 'warn');
+
+    if (typeErrors.length > 0) {
+      console.log(`[ERROR] ${typeName}`);
+      for (const d of typeErrors) {
+        for (const line of d.message.split('\n')) {
+          console.log(`  ${line}`);
+        }
+        printSuggestions(d.suggestions);
+      }
+      console.log('');
+    }
+
+    if (typeWarns.length > 0) {
+      console.log(`[WARN] ${typeName}`);
+      for (const d of typeWarns) {
+        for (const line of d.message.split('\n')) {
+          console.log(`  ${line}`);
+        }
+        printSuggestions(d.suggestions);
+      }
+      console.log('');
+    }
+  }
+
+  printSummary(totalResponseCount, errors.length, warns.length);
+}
+
+function printSuggestions(suggestions?: string[]): void {
+  if (!suggestions || suggestions.length === 0) return;
+  console.log('  [제안]');
+  for (const s of suggestions) {
+    console.log(`    ${s}`);
+  }
+}
+
+function printSummary(total: number, errorCount: number, warnCount: number): void {
+  console.log('요약');
+  console.log(`  검사한 Response 타입: ${total}개`);
+  console.log(`  ERROR: ${errorCount}개`);
+  console.log(`  WARN: ${warnCount}개`);
+  console.log('');
+}
+
+function groupByType(diagnostics: Diagnostic[]): Map<string, Diagnostic[]> {
+  const map = new Map<string, Diagnostic[]>();
+
+  for (const d of diagnostics) {
+    const list = map.get(d.typeName) ?? [];
+    list.push(d);
+    map.set(d.typeName, list);
+  }
+
+  return map;
+}

--- a/scripts/schema-lint/rules/responseOptionalRule.ts
+++ b/scripts/schema-lint/rules/responseOptionalRule.ts
@@ -1,0 +1,45 @@
+import { MIN_FIELDS_FOR_ALL_OPTIONAL_ERROR } from '../constants.js';
+import type { Diagnostic, ParsedResponse } from '../types.js';
+
+/**
+ * Response 타입의 optional 필드 비율을 검사한다.
+ *
+ * ERROR 조건:
+ * - 필드가 MIN_FIELDS_FOR_ALL_OPTIONAL_ERROR개 이상인데 전부 optional
+ * - required 필드가 0개
+ */
+export function responseOptionalRule(responses: ParsedResponse[]): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+
+  for (const response of responses) {
+    const { name, fields } = response;
+
+    if (fields.length === 0) continue;
+
+    const requiredCount = fields.filter((f) => !f.optional).length;
+    const optionalCount = fields.filter((f) => f.optional).length;
+
+    const suggestions = [
+      '실제 항상 내려오는 필드를 required로 지정하세요.',
+      'Spring 사용 시: @Schema(requiredMode = REQUIRED), @NotNull',
+    ];
+
+    if (requiredCount === 0 && fields.length >= MIN_FIELDS_FOR_ALL_OPTIONAL_ERROR) {
+      diagnostics.push({
+        severity: 'error',
+        typeName: name,
+        message: `전체 ${fields.length}개 필드가 모두 optional입니다.`,
+        suggestions,
+      });
+    } else if (requiredCount === 0 && fields.length > 0) {
+      diagnostics.push({
+        severity: 'error',
+        typeName: name,
+        message: `required 필드가 0개입니다. (전체 ${fields.length}개 필드, 모두 optional)`,
+        suggestions,
+      });
+    }
+  }
+
+  return diagnostics;
+}

--- a/scripts/schema-lint/rules/typoRule.ts
+++ b/scripts/schema-lint/rules/typoRule.ts
@@ -1,0 +1,77 @@
+import {
+  COMMON_TYPOS,
+  EDIT_DISTANCE_THRESHOLD,
+  MIN_FIELD_LENGTH_FOR_SIMILARITY,
+} from '../constants.js';
+import type { Diagnostic, ParsedResponse } from '../types.js';
+
+/**
+ * 필드명 오타를 감지한다.
+ *
+ * 1단계: 흔한 오타 사전 기반 (ERROR 수준으로 신뢰도 높음)
+ * 2단계: 편집 거리 기반 유사 필드 감지 (WARN 전용, 보수적)
+ */
+export function typoRule(responses: ParsedResponse[]): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+
+  for (const response of responses) {
+    for (const field of response.fields) {
+      // 1단계: 사전 기반 오타 감지
+      for (const [typo, correct] of COMMON_TYPOS) {
+        if (field.name.includes(typo)) {
+          const suggested = field.name.replace(typo, correct);
+          diagnostics.push({
+            severity: 'warn',
+            typeName: response.name,
+            message: `오타 의심 필드: ${field.name}`,
+            suggestions: [`필드명 수정: ${field.name} → ${suggested}`],
+          });
+        }
+      }
+    }
+
+    // 2단계: 같은 Response 내 유사 필드명 감지
+    const fieldNames = response.fields.map((f) => f.name);
+
+    for (let i = 0; i < fieldNames.length; i++) {
+      for (let j = i + 1; j < fieldNames.length; j++) {
+        const a = fieldNames[i]!;
+        const b = fieldNames[j]!;
+
+        if (
+          a.length >= MIN_FIELD_LENGTH_FOR_SIMILARITY &&
+          b.length >= MIN_FIELD_LENGTH_FOR_SIMILARITY &&
+          levenshtein(a, b) <= EDIT_DISTANCE_THRESHOLD
+        ) {
+          diagnostics.push({
+            severity: 'warn',
+            typeName: response.name,
+            message: `유사한 필드명 감지: "${a}" ↔ "${b}" (편집 거리 ${levenshtein(a, b)})`,
+            suggestions: ['의도적인 구분이 아니라면 필드명을 통일하세요.'],
+          });
+        }
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+/** Levenshtein 편집 거리 계산 */
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0) as number[]);
+
+  for (let i = 0; i <= m; i++) dp[i]![0] = i;
+  for (let j = 0; j <= n; j++) dp[0]![j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i]![j] = Math.min(dp[i - 1]![j]! + 1, dp[i]![j - 1]! + 1, dp[i - 1]![j - 1]! + cost);
+    }
+  }
+
+  return dp[m]![n]!;
+}

--- a/scripts/schema-lint/types.ts
+++ b/scripts/schema-lint/types.ts
@@ -1,0 +1,24 @@
+/** 파싱된 필드 정보 */
+export type ParsedField = {
+  name: string;
+  optional: boolean;
+  typeText: string;
+};
+
+/** 파싱된 Response 타입 정보 */
+export type ParsedResponse = {
+  name: string;
+  fields: ParsedField[];
+};
+
+/** 규칙 검사 결과 심각도 */
+export type Severity = 'error' | 'warn';
+
+/** 개별 진단 항목 */
+export type Diagnostic = {
+  severity: Severity;
+  typeName: string;
+  message: string;
+  /** 백엔드에 전달할 수정 제안 (여러 줄 가능) */
+  suggestions?: string[];
+};


### PR DESCRIPTION
## 📝 PR 유형

* [x] 🚀 feature 기능 추가
* [ ] 🐞 버그 발생
* [ ] 🔨 리팩토링
* [ ] 📋 문서작성
* [ ] 🌍 빌드 설정 및 문제
* [ ] ETC

## 🔔 관련된 이슈 넘버

close #195

## ✅ 작업 목록

* OpenAPI 기반 Response 스키마 lint 스크립트 구현
* TypeScript AST 파싱을 통한 Response 타입 분석 로직 작성
* `required 필드 0개` 케이스 검출 기능 추가
* `ApiResponse` prefix 타입 제외 처리 (노이즈 제거)
* 오타 의심 필드 탐지 및 자동 수정 제안 기능 추가
  (예: `inAvarageEvaluation → inAverageEvaluation`)
* CLI 환경에서 실행 가능한 리포트 출력 기능 구현
* 한국어 기반 리포트 메시지 포맷 구성
* 에러 발생 시 exit code 반환하도록 처리 (CI 연동 가능)

## 🍰 논의사항

* 현재 일부 Response 타입에서 `required 필드가 정의되지 않은 문제` 확인됨
  → 프론트에서 불필요한 방어 코드가 증가하는 원인

* 다음 방향 논의 필요:

  1. 백엔드에서 `@Schema(requiredMode = REQUIRED)` 또는 `@NotNull` 기준 정의
  2. 어떤 필드를 required로 볼지 명확한 기준 수립

* 향후 확장:

  * PR 단계에서 자동으로 lint 결과 코멘트 달기 (GitHub Actions 연동)
  * Swagger/OpenAPI 스펙과의 정합성 검사 추가

---

## 📷 ETC

### 예시 리포트 출력

```
[ERROR] WeeklyDetailReportResponse
- required 필드 개수가 0개입니다.

[제안]
- 실제 항상 내려오는 필드를 required로 지정하세요.
- Spring 사용 시:
  @Schema(requiredMode = REQUIRED)
  @NotNull
```

```
오타 의심: inAvarageEvaluation
→ 제안: inAverageEvaluation
```

### 실제 예시 리포트
```
대상 파일: /Users/hyun907/Nitrogen_Front/apps/web/src/shared/api/schema.d.ts

Schema Lint 리포트
==================

[ERROR] IdResponse
  required 필드가 0개입니다. (전체 1개 필드, 모두 optional)

[ERROR] AuthResponse
  전체 11개 필드가 모두 optional입니다. required 필드를 명시해주세요.

[ERROR] EvaluationGroupResponse
  전체 5개 필드가 모두 optional입니다. required 필드를 명시해주세요.

[ERROR] ExpenseItemResponse
  전체 3개 필드가 모두 optional입니다. required 필드를 명시해주세요.

[ERROR] WeeklyExpenseDetailResponse
  전체 5개 필드가 모두 optional입니다. required 필드를 명시해주세요.

[ERROR] ExpenseSimpleResponse
  required 필드가 0개입니다. (전체 2개 필드, 모두 optional)

[ERROR] WeeklyDetailReportResponse
  전체 8개 필드가 모두 optional입니다. required 필드를 명시해주세요.

[WARN] WeeklyDetailReportResponse
  오타 의심 필드: inAvarageEvaluation
    → 제안: inAverageEvaluation

[ERROR] MonthlyReportSummaryResponse
  전체 4개 필드가 모두 optional입니다. required 필드를 명시해주세요.

[ERROR] SummaryRecordResponse
  required 필드가 0개입니다. (전체 2개 필드, 모두 optional)

[ERROR] WeeklyReportResponse
  전체 5개 필드가 모두 optional입니다. required 필드를 명시해주세요.

요약
  검사한 Response 타입: 10개
  ERROR: 10개
  WARN: 1개
```

<img width="570" height="620" alt="image" src="https://github.com/user-attachments/assets/f7ff3f72-9dec-4ed1-bef7-3800d2f11051" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * API 스키마 검증을 위한 새로운 린팅 도구와 실행 스크립트 추가
* **New Features**
  * 응답 타입의 필수 필드 누락을 에러로 감지
  * 필드명 오타 감지 및 유사성(편집거리) 기반 경고 추가
  * 콘솔에 가독성 높은 검사 리포트 출력 및 실패 시 비정상 종료 코드 반환
* **Documentation**
  * 사용법과 검사 규칙을 설명하는 README 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->