### PR TITLE
Refactor: Context API로 BottomSheet onClose props drilling 제거

### DIFF
--- a/apps/web/src/features/datePickerModal/ui/DatePickerBottomSheet.tsx
+++ b/apps/web/src/features/datePickerModal/ui/DatePickerBottomSheet.tsx
@@ -10,8 +10,6 @@ export interface DatePickerBottomSheetTemplateProps {
   initialMonth: number;
   /** 선택 버튼 클릭 시 콜백 */
   onConfirm?: (year: number, month: number) => void;
-  /** X 버튼 클릭 시 콜백 */
-  onClose?: () => void;
   /** 미래 날짜 선택 허용 여부 (기본값: false) */
   allowFuture?: boolean;
 }
@@ -26,7 +24,6 @@ export const DatePickerBottomSheetTemplate = ({
   initialYear,
   initialMonth,
   onConfirm,
-  onClose,
   allowFuture = false,
 }: DatePickerBottomSheetTemplateProps) => {
   const [tempValue, setTempValue] = useState({ year: initialYear, month: initialMonth });
@@ -65,7 +62,7 @@ export const DatePickerBottomSheetTemplate = ({
 
   return (
     <BaseBottomSheetTemplate>
-      <BaseBottomSheetTemplate.Header type='close' text='월 선택' onClose={onClose} />
+      <BaseBottomSheetTemplate.Header type='close' text='월 선택' />
       <div className={styles.pickerWrapper}>
         <DatePicker
           value={tempValue}

--- a/apps/web/src/features/datePickerModal/ui/DatePickerFeature.tsx
+++ b/apps/web/src/features/datePickerModal/ui/DatePickerFeature.tsx
@@ -44,7 +44,6 @@ export const DatePickerFeature = ({
           initialYear={currentDate.getFullYear()}
           initialMonth={currentDate.getMonth() + 1}
           onConfirm={handleConfirm}
-          onClose={closeModal}
           allowFuture={false}
         />
       </BottomSheet>

--- a/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
@@ -223,7 +223,6 @@ export const ExpenseEditBottomSheet = ({
         onCategorySelect={(cat) => setSelectedCategoryId(cat.id)}
         onConfirm={handleConfirm}
         onDelete={handleDelete}
-        onClose={onClose}
         selectedDate={date}
         onDateClick={() => setIsCalendarOpen(true)}
         onMoreCategoryClick={() => setIsCategorySheetOpen(true)}
@@ -251,7 +250,6 @@ export const ExpenseEditBottomSheet = ({
             if (newDate) setDate(newDate);
           }}
           onConfirm={() => setIsCalendarOpen(false)}
-          onClose={() => setIsCalendarOpen(false)}
         />
       </BottomSheet>
       <BottomSheet isOpen={isCategorySheetOpen} onClose={() => setIsCategorySheetOpen(false)}>

--- a/apps/web/src/features/expense/ui/expenseBottomSheet/DatePickerBottomSheet.stories.tsx
+++ b/apps/web/src/features/expense/ui/expenseBottomSheet/DatePickerBottomSheet.stories.tsx
@@ -35,7 +35,6 @@ const meta = {
           '  selectedDate={selectedDate}',
           '  onSelectDate={setSelectedDate}',
           '  onConfirm={() => {}}',
-          '  onClose={() => {}}',
           '/>',
           '```',
         ].join('\n'),
@@ -61,12 +60,6 @@ const meta = {
       description: '선택 버튼 클릭 시 콜백',
       table: {
         type: { summary: '(year: number, month: number) => void' },
-      },
-    },
-    onClose: {
-      description: '닫기 버튼 클릭 시 콜백',
-      table: {
-        type: { summary: '() => void' },
       },
     },
     allowFuture: {
@@ -110,7 +103,6 @@ export const Default: Story = {
           <BottomSheet isOpen={isOpen} onClose={closeModal}>
             <DatePickerBottomSheetTemplate
               {...args}
-              onClose={closeModal}
               onConfirm={(year, month) => {
                 alert(`선택된 월: ${year}년 ${month}월`);
                 closeModal();

--- a/apps/web/src/features/expense/ui/expenseBottomSheet/DatePickerBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/expenseBottomSheet/DatePickerBottomSheet.tsx
@@ -10,8 +10,6 @@ export interface DatePickerBottomSheetTemplateProps {
   initialMonth: number;
   /** 선택 버튼 클릭 시 콜백 */
   onConfirm?: (year: number, month: number) => void;
-  /** X 버튼 클릭 시 콜백 */
-  onClose?: () => void;
   /** 미래 날짜 선택 허용 여부 (기본값: false) */
   allowFuture?: boolean;
 }
@@ -20,7 +18,6 @@ export const DatePickerBottomSheetTemplate = ({
   initialYear,
   initialMonth,
   onConfirm,
-  onClose,
   allowFuture = false,
 }: DatePickerBottomSheetTemplateProps) => {
   const [tempValue, setTempValue] = useState({ year: initialYear, month: initialMonth });
@@ -59,7 +56,7 @@ export const DatePickerBottomSheetTemplate = ({
 
   return (
     <BaseBottomSheetTemplate>
-      <BaseBottomSheetTemplate.Header type='close' text='월 선택' onClose={onClose} />
+      <BaseBottomSheetTemplate.Header type='close' text='월 선택' />
       <div className={styles.pickerWrapper}>
         <DatePicker
           value={tempValue}

--- a/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.stories.tsx
+++ b/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.stories.tsx
@@ -46,7 +46,6 @@ const meta = {
           '  selectedCategoryId={selectedCategoryId}',
           '  onCategorySelect={(category) => setSelectedCategoryId(category.id)}',
           '  onConfirm={() => {}}',
-          '  onClose={() => {}}',
           '/>',
           '```',
         ].join('\n'),
@@ -119,12 +118,6 @@ const meta = {
         type: { summary: '() => void' },
       },
     },
-    onClose: {
-      description: '닫기 버튼 클릭 시 콜백',
-      table: {
-        type: { summary: '() => void' },
-      },
-    },
   },
 } satisfies Meta<typeof ExpenseFormBottomSheet>;
 
@@ -169,7 +162,6 @@ export const Default: Story = {
               satisfactionLabel='만족도 낮음'
               satisfactionEmoji='😒'
               onDelete={() => alert('삭제')}
-              onClose={closeModal}
               onConfirm={() => {
                 alert('소비 입력 완료');
                 closeModal();
@@ -232,7 +224,6 @@ export const EmptyForm: Story = {
               onCategorySelect={(category) => setSelectedCategoryId(category.id)}
               onMoreCategoryClick={() => alert('더보기 클릭')}
               onDelete={() => alert('삭제')}
-              onClose={closeModal}
               onConfirm={() => {
                 alert('소비 입력 완료');
                 closeModal();

--- a/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/expenseBottomSheet/ExpenseFormBottomSheet.tsx
@@ -51,8 +51,6 @@ export interface ExpenseFormBottomSheetProps {
   onDelete?: () => void;
   /** 선택 버튼 클릭 시 콜백 */
   onConfirm?: () => void;
-  /** X 버튼 클릭 시 콜백 */
-  onClose?: () => void;
   /** 확인 버튼 비활성화 여부 */
   confirmDisabled?: boolean;
   /** 소비 금액 에러 메세지 */
@@ -79,7 +77,6 @@ export const ExpenseFormBottomSheet = ({
   satisfactionEvaluationType,
   onDelete,
   onConfirm,
-  onClose,
   confirmDisabled,
   amountErrorMessage,
   isAmountError,
@@ -98,7 +95,7 @@ export const ExpenseFormBottomSheet = ({
 
   return (
     <BaseBottomSheetTemplate>
-      <BaseBottomSheetTemplate.Header type='close' onClose={onClose} />
+      <BaseBottomSheetTemplate.Header type='close' />
 
       {/* 소비금액 */}
       <InputField label='소비금액'>

--- a/apps/web/src/features/expense/ui/expenseBottomSheet/IconPickerBottomSheet.stories.tsx
+++ b/apps/web/src/features/expense/ui/expenseBottomSheet/IconPickerBottomSheet.stories.tsx
@@ -39,7 +39,6 @@ const meta = {
           '  selectedId={selectedId}',
           '  onSelect={(category) => setSelectedId(category.id)}',
           '  onConfirm={() => {}}',
-          '  onClose={() => {}}',
           '/>',
           '```',
         ].join('\n'),
@@ -68,12 +67,6 @@ const meta = {
     },
     onConfirm: {
       description: '선택 버튼 클릭 시 콜백',
-      table: {
-        type: { summary: '() => void' },
-      },
-    },
-    onClose: {
-      description: '닫기 버튼 클릭 시 콜백',
       table: {
         type: { summary: '() => void' },
       },
@@ -134,7 +127,6 @@ export const Default: Story = {
               categories={mockCategories}
               selectedId={selectedId}
               onSelect={(category) => setSelectedId(category.id)}
-              onClose={closeModal}
               onConfirm={() => {
                 alert(`선택된 아이콘: ${selectedId}`);
                 closeModal();

--- a/apps/web/src/features/expense/ui/expenseBottomSheet/IconPickerBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/expenseBottomSheet/IconPickerBottomSheet.tsx
@@ -11,8 +11,6 @@ export interface IconPickerBottomSheetTemplateProps {
   onSelect?: (category: CategoryItem) => void;
   /** 선택 버튼 클릭 시 콜백 */
   onConfirm?: () => void;
-  /** X 버튼 클릭 시 콜백 */
-  onClose?: () => void;
 }
 
 export const IconPickerBottomSheetTemplate = ({
@@ -20,11 +18,10 @@ export const IconPickerBottomSheetTemplate = ({
   selectedId,
   onSelect,
   onConfirm,
-  onClose,
 }: IconPickerBottomSheetTemplateProps) => {
   return (
     <BaseBottomSheetTemplate>
-      <BaseBottomSheetTemplate.Header type='close' text='아이콘' onClose={onClose} />
+      <BaseBottomSheetTemplate.Header type='close' text='아이콘' />
       <BaseBottomSheetTemplate.Content>
         <div className={styles.categoryGrid}>
           {categories.map((category) => (

--- a/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.tsx
+++ b/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.tsx
@@ -154,7 +154,6 @@ export const AddCategoryStep = ({ onBack }: AddCategoryStepProps) => {
           selectedId={tempIcon?.id}
           onSelect={setTempIcon}
           onConfirm={handleConfirm}
-          onClose={closeBottomSheet}
         />
       </BottomSheet>
       <BottomFixedArea zIndex={1}>

--- a/apps/web/src/features/expense/ui/steps/AmountDateStep/AmountDateStep.tsx
+++ b/apps/web/src/features/expense/ui/steps/AmountDateStep/AmountDateStep.tsx
@@ -44,7 +44,6 @@ export const AmountDateStep = ({ onNext, defaultAmount, defaultDate }: AmountDat
           onSelectDate={(date) => {
             if (date) setSelectedDate(date);
           }}
-          onClose={closeModal}
           onConfirm={closeModal}
         />
       </BottomSheet>

--- a/apps/web/src/features/expense/ui/steps/AmountDateStep/CalendarBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/steps/AmountDateStep/CalendarBottomSheet.tsx
@@ -14,14 +14,12 @@ interface CalendarBottomSheetTemplateProps {
   selectedDate?: Date;
   onSelectDate?: (date: Date | null) => void;
   onConfirm?: () => void;
-  onClose?: () => void;
 }
 
 export const CalendarBottomSheetTemplate = ({
   selectedDate: initialDate,
   onSelectDate,
   onConfirm,
-  onClose,
 }: CalendarBottomSheetTemplateProps) => {
   const [selectedDate, setSelectedDate] = useState<Date | null | undefined>(initialDate);
   const [currentDate, setCurrentDate] = useState<Date>(initialDate || new Date());
@@ -43,7 +41,7 @@ export const CalendarBottomSheetTemplate = ({
 
   return (
     <BaseBottomSheetTemplate>
-      <BaseBottomSheetTemplate.Header type='close' text='소비일 수정' onClose={onClose} />
+      <BaseBottomSheetTemplate.Header type='close' text='소비일 수정' />
       <div>
         <MonthlyCalendar
           currentDate={currentDate}

--- a/apps/web/src/shared/ui/bottomSheet/BottomSheet.tsx
+++ b/apps/web/src/shared/ui/bottomSheet/BottomSheet.tsx
@@ -3,6 +3,7 @@
 import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { BottomSheetContext } from './BottomSheetContext';
 import * as styles from './BottomSheet.css';
 
 export interface BottomSheetProps {
@@ -67,7 +68,7 @@ export const BottomSheet = ({
       <div
         className={styles.sheet({ animating: isAnimating })}
         onClick={(e) => e.stopPropagation()}>
-        {children}
+        <BottomSheetContext.Provider value={{ onClose }}>{children}</BottomSheetContext.Provider>
       </div>
     </div>,
     document.body

--- a/apps/web/src/shared/ui/bottomSheet/BottomSheetContext.tsx
+++ b/apps/web/src/shared/ui/bottomSheet/BottomSheetContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { createContext, useContext } from 'react';
 
 interface BottomSheetContextValue {

--- a/apps/web/src/shared/ui/bottomSheet/BottomSheetContext.tsx
+++ b/apps/web/src/shared/ui/bottomSheet/BottomSheetContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+interface BottomSheetContextValue {
+  onClose: () => void;
+}
+
+export const BottomSheetContext = createContext<BottomSheetContextValue | null>(null);
+
+export const useBottomSheetContext = (): BottomSheetContextValue => {
+  const ctx = useContext(BottomSheetContext);
+  if (!ctx) throw new Error('useBottomSheetContext must be used within BottomSheet');
+  return ctx;
+};

--- a/apps/web/src/shared/ui/bottomSheet/index.ts
+++ b/apps/web/src/shared/ui/bottomSheet/index.ts
@@ -1,3 +1,4 @@
 export { BottomSheet } from './BottomSheet';
 export type { BottomSheetProps } from './BottomSheet';
 export { BaseBottomSheetTemplate } from './templates';
+export { useBottomSheetContext } from './BottomSheetContext';

--- a/apps/web/src/shared/ui/bottomSheet/templates/BaseBottomSheetTemplate.tsx
+++ b/apps/web/src/shared/ui/bottomSheet/templates/BaseBottomSheetTemplate.tsx
@@ -12,6 +12,7 @@ import { Text } from '../../text';
 import { vars } from '../../theme.css';
 import { IcClear, IcPlusSimple } from 'public/icons';
 import { Button } from '../../button';
+import { useBottomSheetContext } from '../BottomSheetContext';
 
 interface BottomSheetButtonProps {
   label: string;
@@ -23,7 +24,6 @@ interface BottomSheetHeaderProps {
   text?: string;
   type?: headerType;
   onClickAddBtn?: () => void;
-  onClose?: () => void;
 }
 
 const BaseBottomSheetTemplate = ({ children }: { children: React.ReactNode }) => {
@@ -40,12 +40,8 @@ const BottomSheetContent = ({
   return <div className={className}>{children}</div>;
 };
 
-const BottomSheetHeader = ({
-  text,
-  type = 'close',
-  onClickAddBtn,
-  onClose,
-}: BottomSheetHeaderProps) => {
+const BottomSheetHeader = ({ text, type = 'close', onClickAddBtn }: BottomSheetHeaderProps) => {
+  const { onClose } = useBottomSheetContext();
   return (
     <div className={bottomSheetHeaderWrapper}>
       <Text variant='t1' color={vars.color.text.primary}>

--- a/apps/web/src/widgets/addCategory/ui/AddCategory.tsx
+++ b/apps/web/src/widgets/addCategory/ui/AddCategory.tsx
@@ -198,7 +198,6 @@ export const AddCategory = () => {
           selectedId={tempIcon?.id}
           onSelect={setTempIcon}
           onConfirm={handleConfirm}
-          onClose={closeBottomSheet}
         />
       </BottomSheet>
       <BottomFixedArea zIndex={1}>


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
- close #54

## ✅ 작업 목록

### 문제 상황: Compound Component 패턴 사용 시 props drilling이 심화되어 유지보수성 저하 우려

`BottomSheet`가 이미 `onClose`를 갖고 있음에도, 그 안에 렌더되는 컴포넌트들도 독립적으로 `onClose`를 prop으로 받아서 아래로 전달해야 했습니다.

```
ExpenseEditBottomSheet
  ├─ onClose 소유
  ├─ <BottomSheet onClose={onClose}>              ← BottomSheet에 전달
  └─ <ExpenseFormBottomSheet onClose={onClose}>   ← 또 전달 (drilling)
       └─ <BaseBottomSheetTemplate.Header onClose={onClose}>  ← 또 전달
```

### 변경 내용

#### 1. `BottomSheetContext` 생성

```tsx
// BottomSheetContext.tsx
export const BottomSheetContext = createContext<{ onClose: () => void } | null>(null);
export const useBottomSheetContext = () => useContext(BottomSheetContext);
```

#### 2. `BottomSheet`가 Context 제공

```tsx
// BottomSheet.tsx - children을 Provider로 감쌈
<BottomSheetContext.Provider value={{ onClose }}>
  {children}
</BottomSheetContext.Provider>
```

#### 3. `Header`가 Context에서 직접 읽음

```tsx
// BaseBottomSheetTemplate.tsx
const BottomSheetHeader = ({ text, type, onClickAddBtn }) => {
  const { onClose } = useBottomSheetContext(); // ← prop 대신 Context
  ...
}
```

### 개선된 구조

```
ExpenseEditBottomSheet
  ├─ onClose 소유
  └─ <BottomSheet onClose={onClose}>   ← 여기 한 번만 전달, Context 제공
       └─ <ExpenseFormBottomSheet>     ← onClose prop 불필요
            └─ <Header>                ← Context에서 직접 읽음
```

`onClose`를 소유한 `BottomSheet`와 실제로 사용하는 `Header` 사이의 중간 컴포넌트들이 `onClose`를 전혀 알 필요가 없어졌습니다. 앞으로 새 템플릿을 만들 때도 props에 `onClose`를 선언하지 않아도 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 바텀시트 컴포넌트의 닫기 기능 처리 방식을 개선했습니다. React Context를 활용한 새로운 구조로 변경하여 코드 관리를 단순화했습니다. 사용자 경험에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->