### PR TITLE
Refactor: expense/category mutation 정책을 queries 레이어로 일원화

### DIFF
--- a/apps/web/src/features/expense/api/index.ts
+++ b/apps/web/src/features/expense/api/index.ts
@@ -1,3 +1,0 @@
-export { getCategoryList } from './getCategoryList';
-export { updateExpense } from './updateExpense';
-export { deleteExpense } from './deleteExpense';

--- a/apps/web/src/features/expense/model/expenseQueries.ts
+++ b/apps/web/src/features/expense/model/expenseQueries.ts
@@ -1,11 +1,31 @@
-import { mutationOptions } from '@tanstack/react-query';
+import { mutationOptions, type QueryClient } from '@tanstack/react-query';
 import { postExpense } from '../api/postExpense';
-import type { ExpenseDetailsDTO } from './types';
+import { updateExpense } from '../api/updateExpense';
+import { deleteExpense } from '../api/deleteExpense';
+import type { ExpenseDetailsDTO, UpdateExpenseRequest } from './types';
+import { expenseQueries as entityExpenseQueries } from '@/entities/expense';
+import { expenseReportQueries } from '@/entities/expenseReport';
+
+const invalidateExpenseCaches = (queryClient: QueryClient) => {
+  queryClient.invalidateQueries({ queryKey: entityExpenseQueries.all });
+  queryClient.invalidateQueries({ queryKey: expenseReportQueries.all });
+};
 
 export const expenseQueries = {
-  all: ['expense'] as const,
-  recordMutation: () =>
+  recordMutation: (queryClient: QueryClient) =>
     mutationOptions({
       mutationFn: (body: ExpenseDetailsDTO) => postExpense(body),
+      onSuccess: () => invalidateExpenseCaches(queryClient),
+    }),
+  updateMutation: (queryClient: QueryClient) =>
+    mutationOptions({
+      mutationFn: ({ expenseId, data }: { expenseId: number; data: UpdateExpenseRequest }) =>
+        updateExpense(expenseId, data),
+      onSuccess: () => invalidateExpenseCaches(queryClient),
+    }),
+  deleteMutation: (queryClient: QueryClient) =>
+    mutationOptions({
+      mutationFn: (expenseId: number) => deleteExpense(expenseId),
+      onSuccess: () => invalidateExpenseCaches(queryClient),
     }),
 };

--- a/apps/web/src/features/expense/model/index.ts
+++ b/apps/web/src/features/expense/model/index.ts
@@ -1,4 +1,3 @@
 export * from './categoryQueries';
 export * from './expenseQueries';
 export * from './types';
-export * from '../api';

--- a/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
@@ -11,18 +11,11 @@ import { CalendarBottomSheetTemplate } from '@/features/expense/ui/steps/AmountD
 import { ExpenseFormBottomSheet } from './expenseBottomSheet';
 import {
   categoryQueries,
+  expenseQueries,
   type CategoryListResponseDTO,
-  updateExpense,
-  deleteExpense,
   type UpdateExpenseRequest,
 } from '@/features/expense/model';
-import {
-  EXPENSE_CONSTANTS,
-  EXPENSE_ERROR_MESSAGES,
-  expenseQueries as entityExpenseQueries,
-  type ExpenseListDTO,
-} from '@/entities/expense';
-import { expenseReportQueries } from '@/entities/expenseReport';
+import { EXPENSE_CONSTANTS, EXPENSE_ERROR_MESSAGES, type ExpenseListDTO } from '@/entities/expense';
 import { expenseEditNavigation } from '@/features/expense/lib/expenseEditNavigation';
 import { handleApiError } from '@/shared/api';
 
@@ -74,48 +67,8 @@ export const ExpenseEditBottomSheet = ({
     return (categoryData?.result ?? []) as CategoryListResponseDTO[];
   }, [categoryData]);
 
-  const updateMutation = useMutation({
-    mutationFn: ({ expenseId, data }: { expenseId: number; data: UpdateExpenseRequest }) =>
-      updateExpense(expenseId, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: entityExpenseQueries.all });
-      queryClient.invalidateQueries({ queryKey: expenseReportQueries.all });
-      toast.success('소비 기록이 수정되었어요.');
-      onConfirm?.({
-        ...expense!,
-        amount,
-        usageHistory: usage,
-      });
-      onClose();
-    },
-    onError: (error) => {
-      handleApiError(error, {
-        toast,
-        fallback: '수정에 실패했어요. 다시 시도해 주세요.',
-        context: 'expense.update',
-      });
-    },
-  });
-  // 지출 삭제 mutation
-  const deleteMutation = useMutation({
-    mutationFn: (expenseId: number) => deleteExpense(expenseId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: entityExpenseQueries.all });
-      queryClient.invalidateQueries({ queryKey: expenseReportQueries.all });
-      toast.success('소비 기록이 삭제되었어요.');
-      if (expense?.expenseId) {
-        onDelete?.(expense.expenseId);
-      }
-      onClose();
-    },
-    onError: (error) => {
-      handleApiError(error, {
-        toast,
-        fallback: '삭제에 실패했어요. 다시 시도해 주세요.',
-        context: 'expense.delete',
-      });
-    },
-  });
+  const updateMutation = useMutation(expenseQueries.updateMutation(queryClient));
+  const deleteMutation = useMutation(expenseQueries.deleteMutation(queryClient));
 
   useEffect(() => {
     if (!isOpen || !expense) return;
@@ -178,10 +131,30 @@ export const ExpenseEditBottomSheet = ({
       emotionType: (expense.emotionType as UpdateExpenseRequest['emotionType']) || '기분 전환',
     };
 
-    updateMutation.mutate({
-      expenseId: expense.expenseId,
-      data: requestData,
-    });
+    updateMutation.mutate(
+      {
+        expenseId: expense.expenseId,
+        data: requestData,
+      },
+      {
+        onSuccess: () => {
+          toast.success('소비 기록이 수정되었어요.');
+          onConfirm?.({
+            ...expense,
+            amount,
+            usageHistory: usage,
+          });
+          onClose();
+        },
+        onError: (error) => {
+          handleApiError(error, {
+            toast,
+            fallback: '수정에 실패했어요. 다시 시도해 주세요.',
+            context: 'expense.update',
+          });
+        },
+      }
+    );
   };
 
   const handleDelete = () => {
@@ -191,10 +164,23 @@ export const ExpenseEditBottomSheet = ({
   };
 
   const handleConfirmDelete = () => {
-    if (expense?.expenseId) {
-      deleteMutation.mutate(expense.expenseId);
-      setIsDeleteDialogOpen(false);
-    }
+    if (!expense?.expenseId) return;
+    const expenseId = expense.expenseId;
+    deleteMutation.mutate(expenseId, {
+      onSuccess: () => {
+        toast.success('소비 기록이 삭제되었어요.');
+        onDelete?.(expenseId);
+        onClose();
+      },
+      onError: (error) => {
+        handleApiError(error, {
+          toast,
+          fallback: '삭제에 실패했어요. 다시 시도해 주세요.',
+          context: 'expense.delete',
+        });
+      },
+    });
+    setIsDeleteDialogOpen(false);
   };
 
   // CategoryListDTO를 ExpenseFormBottomSheet의 Category 타입으로 변환 및 정렬

--- a/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
+++ b/apps/web/src/features/expense/ui/ExpenseEditBottomSheet.tsx
@@ -164,11 +164,12 @@ export const ExpenseEditBottomSheet = ({
   };
 
   const handleConfirmDelete = () => {
-    if (!expense?.expenseId) return;
+    if (!expense?.expenseId || deleteMutation.isPending) return;
     const expenseId = expense.expenseId;
     deleteMutation.mutate(expenseId, {
       onSuccess: () => {
         toast.success('소비 기록이 삭제되었어요.');
+        setIsDeleteDialogOpen(false);
         onDelete?.(expenseId);
         onClose();
       },
@@ -180,7 +181,6 @@ export const ExpenseEditBottomSheet = ({
         });
       },
     });
-    setIsDeleteDialogOpen(false);
   };
 
   // CategoryListDTO를 ExpenseFormBottomSheet의 Category 타입으로 변환 및 정렬
@@ -235,6 +235,8 @@ export const ExpenseEditBottomSheet = ({
         confirmText='삭제하기'
         cancelText='취소'
         onConfirm={handleConfirmDelete}
+        autoCloseOnConfirm={false}
+        isConfirmDisabled={deleteMutation.isPending}
       />
       <BottomSheet isOpen={isCalendarOpen} onClose={() => setIsCalendarOpen(false)}>
         <CalendarBottomSheetTemplate

--- a/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.tsx
+++ b/apps/web/src/features/expense/ui/steps/AddCategoryStep/AddCategoryStep.tsx
@@ -48,27 +48,9 @@ export const AddCategoryStep = ({ onBack }: AddCategoryStepProps) => {
   const { data: categoryData } = useQuery(categoryQueries.listQuery());
   const categories = useMemo(() => categoryData?.result ?? [], [categoryData?.result]);
 
-  const { mutate: createCategory, isPending } = useMutation({
-    ...categoryQueries.createMutation(queryClient),
-    onSuccess: (response) => {
-      queryClient.invalidateQueries({ queryKey: categoryQueries.all });
-      const newId = response.result?.id;
-      if (newId) {
-        selectCategory(newId);
-        setCategoryId(newId);
-      }
-      toast.success('카테고리가 추가되었어요!');
-      useExpenseFormStore.setState({ shouldOpenCategorySheet: false });
-      onBack();
-    },
-    onError: (error) => {
-      handleApiError(error, {
-        toast,
-        fallback: '카테고리 추가에 실패했어요. 다시 시도해 주세요.',
-        context: 'category.create',
-      });
-    },
-  });
+  const { mutate: createCategory, isPending } = useMutation(
+    categoryQueries.createMutation(queryClient)
+  );
 
   const [categoryName, setCategoryName] = useState('');
   const [selectedIcon, setSelectedIcon] = useState<CategoryItem | null>(null);
@@ -109,10 +91,31 @@ export const AddCategoryStep = ({ onBack }: AddCategoryStepProps) => {
 
   const handleSubmit = () => {
     if (!selectedIcon) return;
-    createCategory({
-      name: categoryName,
-      icon: selectedIcon.icon as CategoryDetailsDTO['icon'],
-    });
+    createCategory(
+      {
+        name: categoryName,
+        icon: selectedIcon.icon as CategoryDetailsDTO['icon'],
+      },
+      {
+        onSuccess: (response) => {
+          const newId = response.result?.id;
+          if (newId) {
+            selectCategory(newId);
+            setCategoryId(newId);
+          }
+          toast.success('카테고리가 추가되었어요!');
+          useExpenseFormStore.setState({ shouldOpenCategorySheet: false });
+          onBack();
+        },
+        onError: (error) => {
+          handleApiError(error, {
+            toast,
+            fallback: '카테고리 추가에 실패했어요. 다시 시도해 주세요.',
+            context: 'category.create',
+          });
+        },
+      }
+    );
   };
 
   const handleBack = () => {

--- a/apps/web/src/shared/ui/alertDialog/AlertDialog.tsx
+++ b/apps/web/src/shared/ui/alertDialog/AlertDialog.tsx
@@ -30,6 +30,8 @@ export interface AlertDialogProps {
   onCancel?: () => void;
   /** 확인 버튼 비활성화 */
   isConfirmDisabled?: boolean;
+  /** 확인 버튼 클릭 시 자동으로 다이얼로그를 닫을지 여부. 비동기 작업의 결과(성공/실패)에 따라 닫기 시점을 직접 제어해야 할 때 false로 지정. (기본값: true) */
+  autoCloseOnConfirm?: boolean;
   /** 인라인 모드 (overlay 없이 다이얼로그만 렌더링, Storybook 미리보기용) */
   inline?: boolean;
   /** overlay 클래스 커스터마이징 (위치 조정 등) */
@@ -110,6 +112,7 @@ export const AlertDialog = ({
   onConfirm,
   onCancel,
   isConfirmDisabled = false,
+  autoCloseOnConfirm = true,
   inline = false,
   overlayClassName,
 }: AlertDialogProps): React.JSX.Element | null => {
@@ -118,7 +121,7 @@ export const AlertDialog = ({
   // 이벤트 핸들러
   const handleConfirm = () => {
     onConfirm?.();
-    onClose();
+    if (autoCloseOnConfirm) onClose();
   };
 
   const handleCancel = () => {

--- a/apps/web/src/widgets/addCategory/ui/AddCategory.tsx
+++ b/apps/web/src/widgets/addCategory/ui/AddCategory.tsx
@@ -52,48 +52,13 @@ export const AddCategory = () => {
   const { data: categoryData } = useQuery(categoryQueries.listQuery());
   const categories = useMemo(() => categoryData?.result ?? [], [categoryData?.result]);
 
-  const { mutate: createCategory, isPending: isCreatePending } = useMutation({
-    ...categoryQueries.createMutation(queryClient),
-    onSuccess: async (response) => {
-      setSubmitSuccess(true);
-      await queryClient.invalidateQueries({ queryKey: categoryQueries.all });
-      const newId = response.result?.id;
-      if (newId && !isFromMypage) {
-        selectCategory(newId);
-        setCategoryId(newId);
-      }
-      if (isFromEdit) {
-        router.push('/');
-      } else {
-        router.back();
-      }
-      toast.success('카테고리가 추가되었어요!');
-    },
-    onError: (error) => {
-      handleApiError(error, {
-        toast,
-        fallback: '카테고리 추가에 실패했어요. 다시 시도해 주세요.',
-        context: 'category.create',
-      });
-    },
-  });
+  const { mutate: createCategory, isPending: isCreatePending } = useMutation(
+    categoryQueries.createMutation(queryClient)
+  );
 
-  const { mutate: updateCategory, isPending: isUpdatePending } = useMutation({
-    ...categoryQueries.updateMutation(queryClient),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: categoryQueries.all });
-      await queryClient.invalidateQueries({ queryKey: ['expense'] });
-      toast.success('수정한 내용이 저장되었어요!');
-      router.back();
-    },
-    onError: (error) => {
-      handleApiError(error, {
-        toast,
-        fallback: '카테고리 수정에 실패했어요. 다시 시도해 주세요.',
-        context: 'category.update',
-      });
-    },
-  });
+  const { mutate: updateCategory, isPending: isUpdatePending } = useMutation(
+    categoryQueries.updateMutation(queryClient)
+  );
 
   const isPending = isCreatePending || isUpdatePending;
 
@@ -163,15 +128,55 @@ export const AddCategory = () => {
   const handleSubmit = () => {
     if (!selectedIcon) return;
     if (isEditMode && editId) {
-      updateCategory({
-        categoryId: editId,
-        data: { name: categoryName, icon: selectedIcon.icon as CategoryDetailsDTO['icon'] },
-      });
+      updateCategory(
+        {
+          categoryId: editId,
+          data: { name: categoryName, icon: selectedIcon.icon as CategoryDetailsDTO['icon'] },
+        },
+        {
+          onSuccess: () => {
+            toast.success('수정한 내용이 저장되었어요!');
+            router.back();
+          },
+          onError: (error) => {
+            handleApiError(error, {
+              toast,
+              fallback: '카테고리 수정에 실패했어요. 다시 시도해 주세요.',
+              context: 'category.update',
+            });
+          },
+        }
+      );
     } else {
-      createCategory({
-        name: categoryName,
-        icon: selectedIcon.icon as CategoryDetailsDTO['icon'],
-      });
+      createCategory(
+        {
+          name: categoryName,
+          icon: selectedIcon.icon as CategoryDetailsDTO['icon'],
+        },
+        {
+          onSuccess: (response) => {
+            setSubmitSuccess(true);
+            const newId = response.result?.id;
+            if (newId && !isFromMypage) {
+              selectCategory(newId);
+              setCategoryId(newId);
+            }
+            if (isFromEdit) {
+              router.push('/');
+            } else {
+              router.back();
+            }
+            toast.success('카테고리가 추가되었어요!');
+          },
+          onError: (error) => {
+            handleApiError(error, {
+              toast,
+              fallback: '카테고리 추가에 실패했어요. 다시 시도해 주세요.',
+              context: 'category.create',
+            });
+          },
+        }
+      );
     }
   };
 

--- a/apps/web/src/widgets/expenseRecordFunnel/ui/ExpenseRecordFunnel.tsx
+++ b/apps/web/src/widgets/expenseRecordFunnel/ui/ExpenseRecordFunnel.tsx
@@ -25,8 +25,6 @@ import {
 import { expenseQueries } from '@/features/expense/model/expenseQueries';
 import type { EmotionType } from '@/features/expense/model/types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { expenseReportQueries } from '@/entities/expenseReport';
-import { expenseQueries as entityExpenseQueries } from '@/entities/expense';
 import { ROUTES } from '@/shared/constants';
 import { handleApiError } from '@/shared/api';
 
@@ -87,16 +85,9 @@ export const ExpenseRecordFunnel = () => {
       history.push('만족도입력', { usageHistory, categoryId });
     };
 
-  const { mutate: submitExpense, isPending } = useMutation({
-    ...expenseQueries.recordMutation(),
-    onError: (error) => {
-      handleApiError(error, {
-        toast,
-        fallback: '저장에 실패했어요. 다시 시도해 주세요.',
-        context: 'expense.create',
-      });
-    },
-  });
+  const { mutate: submitExpense, isPending } = useMutation(
+    expenseQueries.recordMutation(queryClient)
+  );
 
   const handleSubmit = (emotionType: EmotionType) => {
     if (isPending) return;
@@ -109,12 +100,16 @@ export const ExpenseRecordFunnel = () => {
       },
       {
         onSuccess: () => {
-          // 월별/일일 지출·요약 캐시 무효화 → 이번 달 지출 금액 등 즉시 반영
-          queryClient.invalidateQueries({ queryKey: entityExpenseQueries.all });
-          queryClient.invalidateQueries({ queryKey: expenseReportQueries.all });
           formStore.reset();
           toast.success('소비 기록이 저장되었어요.');
           router.push(ROUTES.HOME);
+        },
+        onError: (error) => {
+          handleApiError(error, {
+            toast,
+            fallback: '저장에 실패했어요. 다시 시도해 주세요.',
+            context: 'expense.create',
+          });
         },
       }
     );


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🔨 리팩토링
                                        
  ## 🔔 관련된 이슈 넘버                                                                                       
  
  -  close #113                                                                                                
                                                            
  ## ✅ 작업 목록

  ### 1. expense mutation을 queries 레이어로 이동                                                               
  
  - ExpenseEditBottomSheet/ExpenseRecordFunnel에 흩어져 있던 useMutation 선언과 invalidateQueries 로직을    
  expenseQueries로 일원화                                   
  - recordMutation/updateMutation/deleteMutation 모두 QueryClient를 받아 entityExpenseQueries.all +         
  expenseReportQueries.all을 공통 헬퍼(invalidateExpenseCaches)로 무효화                                    
  - UI 레이어는 mutate(vars, { onSuccess, onError }) 콜백으로 화면별
  부수효과(토스트·네비게이션·onConfirm/onDelete 등)만 담당                                                  
                                                            
  ### 2. category mutation의 중복 invalidateQueries 제거                                                        
                                                            
  - AddCategory/AddCategoryStep에서 useMutation({ ...categoryQueries.xxx(qc), onSuccess }) 형태로           
  override하면서 queries 레이어의 onSuccess를 가리고, UI가 직접 invalidateQueries를 다시 호출하던 중복
  패턴을 제거                                                                                               
  - expense와 동일하게 useMutation(categoryQueries.xxx(qc)) + per-call mutate 콜백 구조로 정리
                                                                                                            
  ### 3. 미사용 api 배럴 정리
                                                                                                            
  - features/expense/api/index.ts(updateExpense/deleteExpense/getCategoryList 재내보내기)는 리팩토링 후     
  어디서도 직접 import하지 않아 파일 자체를 삭제
  - 이를 트레일링하던 model/index.ts의 export * from '../api' 한 줄도 제거                                  
                                                                                                            
  🍰 논의사항
                                                                                                            
  ### 컨벤션 결정 사항                                                                                          
  
  - 토스트 위치: UI 레이어 유지. 위치별 메시지("저장됐어요"/"수정됐어요"/"삭제됐어요"/"추가됐어요"/...)가   
  다르고 카테고리 패턴과 일관됨.                            
  - mutation 콜백 합성: queries 레이어 옵션을 spread + override하는 대신, useMutation(queries.xxx(qc))로    
  그대로 받고 화면별 부수효과는 .mutate(vars, { onSuccess, onError })로 주입. 이렇게 하면 queries 레이어의  
  invalidate가 항상 먼저 실행되고 UI 콜백이 뒤따릅니다 (override 시에는 queries 레이어 onSuccess가 가려져서
  실행되지 않음).                                                                                           
                                                            
  ### 동작 변화 (의도된 trade-off)                                                                              
  
  - AddCategory create 플로우의 await invalidate → navigate 순서가 fire-and-forget으로 변경됨.              
  setSubmitSuccess(true)는 동기적으로 navigate 전에 적용되므로 duplicate-name 플래시 방지는 그대로
  동작합니다. navigate 후 페이지가 카테고리 list freshness에 의존하지 않아 UX 영향 없음.                    
  - mutate-level 콜백은 v5에서 컴포넌트 언마운트 시 실행되지 않습니다(mutation observer 콜백은 실행됨). 캐시
   무효화는 queries 레이어에 있으므로 항상 실행되며, submit 중 isPending으로 버튼이 disabled되어 정상       
  플로우에서 언마운트 트리거 가능성은 낮습니다.
                                                                                                            
  ### 후속 cleanup 후보 (이번 PR 범위 외)                                                                       
  
  - queries 레이어에 default onError 부재 → 미래 호출자가 onError를 빠뜨리면 silent 실패. 현재 모든 호출    
  site는 전달하므로 문제 없음. 안전망 필요 시 fallback 추가 검토.
  - expenseQueries.recordMutation vs categoryQueries.createMutation 네이밍 차이. 도메인 어휘(기록 vs 생성)  
  차이로 의도된 부분.                                                                                       
  
  📷 ETC                                                                                                    
                                                            
  기대 효과:                                                                                                
  - UI 컴포넌트 경량화 (mutation 정의·캐시 정책·중복 invalidate 제거)
  - 서버 상태 관리 정책 일관성 확보                                                                         
  - 캐시 전략 변경 시 수정 범위가 queries 레이어로 한정됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 뮤테이션 캐시 무효화 로직을 쿼리 정의에서 일괄 관리하도록 개선했습니다.
  * 비용 및 카테고리 뮤테이션 구성을 표준화하여 일관된 동작을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->